### PR TITLE
Fix range width calculation

### DIFF
--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -487,13 +487,13 @@ defmodule GSS.Spreadsheet do
     def range(row_from, row_to, column_from, column_to)
     when row_from <= row_to and column_from <= column_to
     and row_to < 1001 do
-        column_from_letter = col_index_to_letter(column_from)
-        column_to_letter = col_index_to_letter(column_to)
-        "#{column_from_letter}#{row_from}:#{column_to_letter}#{row_to}"
+        column_from_letters = col_number_to_letters(column_from)
+        column_to_letters = col_number_to_letters(column_to)
+        "#{column_from_letters}#{row_from}:#{column_to_letters}#{row_to}"
     end
     def range(_, _, _, _) do
         raise GSS.InvalidRange,
-            message: "Max rows 1000, max columns 255, `to` value should be greater then `from`"
+            message: "Max rows 1000, `to` value should be greater than `from`"
     end
     @spec range(integer(), integer(), integer(), integer(), state) :: String.t
     def range(row_from, row_to, column_from, column_to, state) do
@@ -505,16 +505,19 @@ defmodule GSS.Spreadsheet do
         for _i <- 1..amount, do: ""
     end
 
-    @spec col_index_to_letter(integer()) :: String.t
-    defp col_index_to_letter(index) do
-        case index do
-          i when i > 0 and i < 27 ->
-            to_string([64 + index])
-          i when i > 26 and i < 256 ->
-            to_string([64 + div(index, 26), 64 + rem(index, 26)])
-          _ ->
-            raise GSS.InvalidColumnIndex, message: "Invalid column index"
-        end
+    @spec col_number_to_letters(integer()) :: String.t
+    def col_number_to_letters(col_number) do
+      indices = index_to_index_list(col_number - 1)
+      charlist = for i <- indices, do: i + ?A
+      to_string(charlist)
+    end
+
+    defp index_to_index_list(index, list \\ [])
+    defp index_to_index_list(index, list) when index >= 26 do
+      index_to_index_list(div(index, 26) - 1, [rem(index, 26) | list])
+    end
+    defp index_to_index_list(index, list) when index >= 0 and index < 26 do
+      [index | list]
     end
 
     @spec maybe_attach_list(state) :: String.t

--- a/test/elixir_google_spreadsheets/spreadsheet_range.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_range.exs
@@ -1,0 +1,41 @@
+defmodule GSS.SpreadsheetRangeTest do
+    use ExUnit.Case, async: true
+
+    describe "range/4 with one row" do
+        test "generates range for length 14" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 14) == "A1:N1"
+        end
+
+        test "generates range for length 26" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 26) == "A1:Z1"
+        end
+
+        test "generates range for length 27" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 27) == "A1:AA1"
+        end
+
+        test "generates range for length 52" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 52) == "A1:AZ1"
+        end
+
+        test "generates range for length 53" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 53) == "A1:BA1"
+        end
+
+        test "genearates range for length 254" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 254) == "A1:IT1"
+        end
+
+        test "generates range for length 255" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 255) == "A1:IU1"
+        end
+
+        test "generates range for length 702" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 702) == "A1:ZZ1"
+        end
+
+        test "generates range for length 703" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 703) == "A1:AAA1"
+        end
+    end
+end

--- a/test/elixir_google_spreadsheets/spreadsheet_test.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_test.exs
@@ -85,42 +85,4 @@ defmodule GSS.SpreadsheetTest do
         {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
         assert result == [@test_row1 ++ [""], @test_row2]
     end
-
-    describe "range/4 with one row" do
-        test "generates range for length 14" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 14) == "A1:N1"
-        end
-
-        test "generates range for length 26" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 26) == "A1:Z1"
-        end
-
-        test "generates range for length 27" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 27) == "A1:AA1"
-        end
-
-        test "generates range for length 52" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 52) == "A1:AZ1"
-        end
-
-        test "generates range for length 53" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 53) == "A1:BA1"
-        end
-
-        test "genearates range for length 254" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 254) == "A1:IT1"
-        end
-
-        test "generates range for length 255" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 255) == "A1:IU1"
-        end
-
-        test "generates range for length 702" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 702) == "A1:ZZ1"
-        end
-
-        test "generates range for length 703" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 703) == "A1:AAA1"
-        end
-    end
 end

--- a/test/elixir_google_spreadsheets/spreadsheet_test.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_test.exs
@@ -85,4 +85,42 @@ defmodule GSS.SpreadsheetTest do
         {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
         assert result == [@test_row1 ++ [""], @test_row2]
     end
+
+    describe "range/4 with one row" do
+        test "generates range for length 14" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 14) == "A1:N1"
+        end
+
+        test "generates range for length 26" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 26) == "A1:Z1"
+        end
+
+        test "generates range for length 27" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 27) == "A1:AA1"
+        end
+
+        test "generates range for length 52" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 52) == "A1:AZ1"
+        end
+
+        test "generates range for length 53" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 53) == "A1:BA1"
+        end
+
+        test "genearates range for length 254" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 254) == "A1:IT1"
+        end
+
+        test "generates range for length 255" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 255) == "A1:IU1"
+        end
+
+        test "generates range for length 702" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 702) == "A1:ZZ1"
+        end
+
+        test "generates range for length 703" do
+            assert GSS.Spreadsheet.range(1, 1, 1, 703) == "A1:AAA1"
+        end
+    end
 end


### PR DESCRIPTION
- There was a bug previously that allowed to generate ranges such as "A2:B@2"