### PR TITLE
Fix issue causing nil column values to result in an unhandled response.

### DIFF
--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -264,11 +264,11 @@ defmodule GSS.Spreadsheet do
         query = "#{spreadsheet_id}/values/#{range}?valueInputOption=#{value_input_option}"
 
         case spreadsheet_query(:put, query, column_list, options ++ [range: range]) do
-            {:json, %{"updatedRows" => 1, "updatedColumns" => updated_columns}}
-            when updated_columns == write_cells_count ->
                 {:reply, :ok, state}
             {:error, exception} ->
                 {:reply, {:error, exception}, state}
+          {:json, %{"updatedRows" => 1, "updatedColumns" => updated_columns}}
+          when updated_columns > 0 ->
         end
     end
 
@@ -293,7 +293,7 @@ defmodule GSS.Spreadsheet do
         case spreadsheet_query(:post, query, column_list, options ++ [range: range]) do
             {:json, %{"updates" => %{
                 "updatedRows" => 1, "updatedColumns" => updated_columns
-            }}} when updated_columns == write_cells_count ->
+            }}} when updated_columns > 0 ->
                 {:reply, :ok, state}
             {:error, exception} ->
                 {:reply, {:error, exception}, state}


### PR DESCRIPTION
When you send row data with nil values in it, the guard clause on the response handler fails to match.

I've removed the check that the number of columns is equal in this case because it shouldn't be. Instead I just check that the number of changes is > 0, in other words that *something* changed.