### PR TITLE
Fix crash when user has not specified a timeout

### DIFF
--- a/lib/elixir_google_spreadsheets/client.ex
+++ b/lib/elixir_google_spreadsheets/client.ex
@@ -69,7 +69,6 @@ defmodule GSS.Client do
     """
     @spec request(atom, binary, HTTPoison.body, HTTPoison.headers, Keyword.t) :: {:ok, HTTPoison.Response.t} | {:error, binary} | no_return
     def request(method, url, body \\ "", headers \\ [], options \\ []) do
-        result_timeout = options[:result_timeout] || config(:result_timeout)
         request = %RequestParams{
           method: method,
           url: url,
@@ -77,7 +76,12 @@ defmodule GSS.Client do
           headers: headers,
           options: options
         }
-        GenStage.call(__MODULE__, {:request, request}, result_timeout)
+        case options[:result_timeout] || config(:result_timeout) do
+          nil ->
+            GenStage.call(__MODULE__, {:request, request})
+          result_timeout ->
+            GenStage.call(__MODULE__, {:request, request}, result_timeout)
+        end
     end
 
     @doc ~S"""
@@ -122,7 +126,7 @@ defmodule GSS.Client do
         {:noreply, Enum.reverse(events), updated_queue}
     end
 
-    
+
     @doc """
     Read config settings scoped for GSS client.
     """

--- a/lib/elixir_google_spreadsheets/client/request.ex
+++ b/lib/elixir_google_spreadsheets/client/request.ex
@@ -64,7 +64,7 @@ defmodule GSS.Client.Request do
         } = request
         Logger.debug "send_request #{url}"
         try do
-            case HTTPoison.request(method, url, body, headers, options) do
+            case HTTPoison.request(method, url, body, headers, options || []) do
                 {:ok, response} ->
                     {:ok, response}
                 {:error, %HTTPoison.Error{reason: reason}} ->

--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -446,14 +446,14 @@ defmodule GSS.Spreadsheet do
     @spec spreadsheet_query(:get | :post, String.t) :: spreadsheet_response
     defp spreadsheet_query(type, url_suffix) when is_atom(type) do
         headers = %{"Authorization" => "Bearer #{GSS.Registry.token}"}
-        params = Client.config(:request_opts)
+        params = Client.config(:request_opts, [ssl: [{:versions, [:'tlsv1.2']}]])
         response = Client.request(type, @api_url_spreadsheet <> url_suffix, "", headers, params)
         spreadsheet_query_response(response)
     end
     @spec spreadsheet_query(:post | :put, String.t, spreadsheet_data, Keyword.t) :: spreadsheet_response
     defp spreadsheet_query(type, url_suffix, data, options) when is_atom(type) do
         headers = %{"Authorization" => "Bearer #{GSS.Registry.token}"}
-        params = Client.config(:request_opts)
+        params = Client.config(:request_opts, [ssl: [{:versions, [:'tlsv1.2']}]])
         response = case type do
             :post ->
                 body = spreadsheet_query_body(data, options)
@@ -566,7 +566,7 @@ defmodule GSS.Spreadsheet do
     defp empty_row(nil, true), do: []
     defp empty_row(column_to, true), do: pad(column_to)
     defp empty_row(_, false), do: nil
-    
+
     @spec value_range_block_wrapper([String.t], integer()) :: [String.t]
     defp value_range_block_wrapper(values, column_to) when length(values) >= column_to, do: values
     defp value_range_block_wrapper(values, column_to) do


### PR DESCRIPTION
In the case that the user has not set a timeout, a call to
Spreadsheet.rows will crash with no function clause matching in :gen.call/4

This is because :gen.call with a fourth argument expects it to be an
integer, not nil.

We can solve this by using the default if the user did not configure a
timeout.