### PR TITLE
Error when spreadsheet query response status code is not 200

### DIFF
--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -481,6 +481,9 @@ defmodule GSS.Spreadsheet do
             {:ok, json} <- Poison.decode(body) do
             {:json, json}
         else
+            {:ok, %{status_code: status_code, body: body}} when status_code != 200 ->
+                Logger.error "Google API returned status code: #{status_code}. Body: #{body}"
+                {:error, GSS.GoogleApiError}
             {:error, reason}->
                 Logger.error fn -> "Spreadsheet query: #{inspect(reason)}" end
                 {:error, GSS.GoogleApiError}


### PR DESCRIPTION
HTTPoison returns bad responses as:

`{:ok, %HTTPoison.Response{status_code: xxx, body: ...}`

As a result, there is no matching `with` clause when the response is 404 for example.

This converts the `{:ok, ...}` tuple to an actual error tuple.