### PR TITLE
Change spreadsheet_response return type to atom

### DIFF
--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -16,7 +16,7 @@ defmodule GSS.Spreadsheet do
     """
     @type state :: map()
     @type spreadsheet_data :: [String.t]
-    @type spreadsheet_response :: {:json, map()} | {:error, Exception.t} | no_return()
+    @type spreadsheet_response :: {:json, map()} | {:error, atom} | no_return()
 
     @api_url_spreadsheet "https://sheets.googleapis.com/v4/spreadsheets/"
     @default_request_params [ssl: [{:versions, [:'tlsv1.2']}]]

--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -106,17 +106,17 @@ defmodule GSS.Spreadsheet do
     use `pad_empty: true` and `column_to: integer` options to fill records
     with an empty string values.
     """
-    @spec read_rows(pid, [String.t] | [integer()]) :: {:ok, [spreadsheet_data | nil]} | {:error, Exception.t}
+    @spec read_rows(pid, [String.t] | [integer()]) :: {:ok, [spreadsheet_data | nil]} | {:error, atom}
     def read_rows(pid, ranges), do: read_rows(pid, ranges, [])
-    @spec read_rows(pid, [String.t] | [integer()], Keyword.t) :: {:ok, [spreadsheet_data]} | {:error, Exception.t}
+    @spec read_rows(pid, [String.t] | [integer()], Keyword.t) :: {:ok, [spreadsheet_data]} | {:error, atom}
     def read_rows(pid, ranges, options) when is_list(ranges) do
       gen_server_call(pid, {:read_rows, ranges, options}, options)
     end
-    @spec read_rows(pid, integer(), integer()) :: {:ok, [spreadsheet_data]} | {:error, Exception.t}
+    @spec read_rows(pid, integer(), integer()) :: {:ok, [spreadsheet_data]} | {:error, atom}
     def read_rows(pid, row_index_start, row_index_end)
     when is_integer(row_index_start) and is_integer(row_index_end), do: read_rows(pid, row_index_start, row_index_end, [])
     def read_rows(_, _, _), do: {:error, GSS.InvalidInput}
-    @spec read_rows(pid, integer(), integer(), Keyword.t) :: {:ok, [spreadsheet_data]} | {:error, Exception.t}
+    @spec read_rows(pid, integer(), integer(), Keyword.t) :: {:ok, [spreadsheet_data]} | {:error, atom}
     def read_rows(pid, row_index_start, row_index_end, options)
     when is_integer(row_index_start) and is_integer(row_index_end) and row_index_start < row_index_end do
       gen_server_call(pid, {:read_rows, row_index_start, row_index_end, options}, options)


### PR DESCRIPTION
In `spreadsheet_query_response` when an error tuple is returned, it's returned as `{:error, GSS.GoogleApiError}`. This returns an atom (`GSS.GoogleApiError`) and not the exception struct `%GSS.GoogleApiError{}`, which breaks checks with dialyzer.