### PR TITLE
Run mix format over entire library

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{lib,test,config}/**/*.{ex,exs}"]
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,22 +27,22 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-config :goth,
-    json: "./config/service_account.json" |> File.read!
+config :goth, json: "./config/service_account.json" |> File.read!()
 
 config :elixir_google_spreadsheets,
-    max_rows_per_request: 301,
-    default_column_from: 1,
-    default_column_to: 26
+  max_rows_per_request: 301,
+  default_column_from: 1,
+  default_column_to: 26
+
 config :elixir_google_spreadsheets, :client,
-    request_workers: 50,
-    max_demand: 100,
-    max_interval: :timer.minutes(1),
-    interval: 100,
-    result_timeout: :timer.minutes(10),
-    request_opts: [
-        timeout: :timer.seconds(8),
-        recv_timeout: :timer.seconds(5)
-    ]
-  
-import_config "#{Mix.env}.exs"
+  request_workers: 50,
+  max_demand: 100,
+  max_interval: :timer.minutes(1),
+  interval: 100,
+  result_timeout: :timer.minutes(10),
+  request_opts: [
+    timeout: :timer.seconds(8),
+    recv_timeout: :timer.seconds(5)
+  ]
+
+import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,10 +1,8 @@
 use Mix.Config
 
-config :elixir_google_spreadsheets,
-  spreadsheet_id: "1h85keViqbRzgTN245gEw5s9roxpaUtT7i-mNXQtT8qQ"
+config :elixir_google_spreadsheets, spreadsheet_id: "1h85keViqbRzgTN245gEw5s9roxpaUtT7i-mNXQtT8qQ"
 
-config :elixir_google_spreadsheets, :client,
-  request_workers: 30
+config :elixir_google_spreadsheets, :client, request_workers: 30
 
 if File.exists?("config/test.local.exs") do
   import_config "test.local.exs"

--- a/lib/elixir_google_spreadsheets.ex
+++ b/lib/elixir_google_spreadsheets.ex
@@ -1,19 +1,19 @@
 defmodule GSS do
-    @moduledoc """
-    Bootstrap Google Spreadsheet application.
-    """
+  @moduledoc """
+  Bootstrap Google Spreadsheet application.
+  """
 
-    use Application
+  use Application
 
-    def start(_type, _args) do
-        GSS.Supervisor.start_link()
-    end
+  def start(_type, _args) do
+    GSS.Supervisor.start_link()
+  end
 
-    @doc """
-    Read config settings scoped for GSS.
-    """
-    @spec config(atom(), any()) :: any()
-    def config(key, default \\ nil) do
-        Application.get_env(:elixir_google_spreadsheets, key, default)
-    end
+  @doc """
+  Read config settings scoped for GSS.
+  """
+  @spec config(atom(), any()) :: any()
+  def config(key, default \\ nil) do
+    Application.get_env(:elixir_google_spreadsheets, key, default)
+  end
 end

--- a/lib/elixir_google_spreadsheets/client.ex
+++ b/lib/elixir_google_spreadsheets/client.ex
@@ -1,151 +1,158 @@
 defmodule GSS.Client do
-    @moduledoc """
-    Model of Client abstraction
-    This process is a Producer for this GenStage pipeline.
-    """
+  @moduledoc """
+  Model of Client abstraction
+  This process is a Producer for this GenStage pipeline.
+  """
 
-    use GenStage
-    require Logger
+  use GenStage
+  require Logger
 
-    defmodule RequestParams do
-        @type t :: %__MODULE__{
+  defmodule RequestParams do
+    @type t :: %__MODULE__{
             method: atom(),
             url: binary(),
             body: HTTPoison.body(),
             headers: HTTPoison.headers(),
             options: Keyword.t()
-        }
-        defstruct [method: nil, url: nil, body: "", headers: [], options: []]
+          }
+    defstruct method: nil, url: nil, body: "", headers: [], options: []
+  end
+
+  @type event :: {:request, GenStage.from(), RequestParams.t()}
+  @type partition :: :write | :read
+
+  @spec start_link() :: GenServer.on_start()
+  def start_link do
+    GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc ~S"""
+  Issues an HTTP request with the given method to the given url.
+
+  This function is usually used indirectly by `get/3`, `post/4`, `put/4`, etc
+
+  Args:
+  * `method` - HTTP method as an atom (`:get`, `:head`, `:post`, `:put`,
+    `:delete`, etc.)
+  * `url` - target url as a binary string or char list
+  * `body` - request body. See more below
+  * `headers` - HTTP headers as an orddict (e.g., `[{"Accept", "application/json"}]`)
+  * `options` - Keyword list of options
+
+  Body:
+  * binary, char list or an iolist
+  * `{:form, [{K, V}, ...]}` - send a form url encoded
+  * `{:file, ~s(/path/to/file)}` - send a file
+  * `{:stream, enumerable}` - lazily send a stream of binaries/charlists
+
+  Options:
+  * `:result_timeout` - receive result timeout, in milliseconds. Default is 2 minutes
+  * `:timeout` - timeout to establish a connection, in milliseconds. Default is 8000
+  * `:recv_timeout` - timeout used when receiving a connection. Default is 5000
+  * `:proxy` - a proxy to be used for the request; it can be a regular url
+    or a `{Host, Port}` tuple
+  * `:proxy_auth` - proxy authentication `{User, Password}` tuple
+  * `:ssl` - SSL options supported by the `ssl` erlang module
+  * `:follow_redirect` - a boolean that causes redirects to be followed
+  * `:max_redirect` - an integer denoting the maximum number of redirects to follow
+  * `:params` - an enumerable consisting of two-item tuples that will be appended to the url as query string parameters
+
+  Timeouts can be an integer or `:infinity`
+
+  This function returns `{:ok, response}` or `{:ok, async_response}` if the
+  request is successful, `{:error, reason}` otherwise.
+
+  ## Examples
+
+    request(:post, ~s(https://my.website.com), ~s({\"foo\": 3}), [{"Accept", "application/json"}])
+
+  """
+  @spec request(atom, binary, HTTPoison.body(), HTTPoison.headers(), Keyword.t()) ::
+          {:ok, HTTPoison.Response.t()} | {:error, binary} | no_return
+  def request(method, url, body \\ "", headers \\ [], options \\ []) do
+    request = %RequestParams{
+      method: method,
+      url: url,
+      body: body,
+      headers: headers,
+      options: options
+    }
+
+    case options[:result_timeout] || config(:result_timeout) do
+      nil ->
+        GenStage.call(__MODULE__, {:request, request})
+
+      result_timeout ->
+        GenStage.call(__MODULE__, {:request, request}, result_timeout)
     end
+  end
 
-    @type event :: {:request, GenStage.from(), RequestParams.t}
-    @type partition :: :write | :read
+  @doc ~S"""
+  Starts a task with request that must be awaited on.
+  """
+  @spec request_async(atom, binary, HTTPoison.body(), HTTPoison.headers(), Keyword.t()) ::
+          Task.t()
+  def request_async(method, url, body \\ "", headers \\ [], options \\ []) do
+    Task.async(GSS.Client, :request, [method, url, body, headers, options])
+  end
 
-    @spec start_link() :: GenServer.on_start()
-    def start_link do
-        GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+  ## Callbacks
+
+  def init(:ok) do
+    dispatcer =
+      {GenStage.PartitionDispatcher, partitions: [:write, :read], hash: &dispatcher_hash/1}
+
+    {:producer, :queue.new(), dispatcher: dispatcer}
+  end
+
+  @doc ~S"""
+  Divide request into to partitions :read and :write
+  """
+  @spec dispatcher_hash(event) :: {event, partition()}
+  def dispatcher_hash({:request, _from, request} = event) do
+    case request.method do
+      :get -> {event, :read}
+      _ -> {event, :write}
     end
+  end
 
-    @doc ~S"""
-    Issues an HTTP request with the given method to the given url.
+  @doc ~S"""
+  Adds an event to the queue
+  """
+  def handle_call({:request, request}, from, queue) do
+    updated_queue = :queue.in({:request, from, request}, queue)
+    {:noreply, [], updated_queue}
+  end
 
-    This function is usually used indirectly by `get/3`, `post/4`, `put/4`, etc
+  @doc ~S"""
+  Gives events for the next stage to process when requested
+  """
+  def handle_demand(demand, queue) when demand > 0 do
+    {events, updated_queue} = take_from_queue(queue, demand, [])
+    {:noreply, Enum.reverse(events), updated_queue}
+  end
 
-    Args:
-    * `method` - HTTP method as an atom (`:get`, `:head`, `:post`, `:put`,
-      `:delete`, etc.)
-    * `url` - target url as a binary string or char list
-    * `body` - request body. See more below
-    * `headers` - HTTP headers as an orddict (e.g., `[{"Accept", "application/json"}]`)
-    * `options` - Keyword list of options
+  @doc """
+  Read config settings scoped for GSS client.
+  """
+  @spec config(atom(), any()) :: any()
+  def config(key, default \\ nil) do
+    Application.get_env(:elixir_google_spreadsheets, :client)
+    |> Keyword.get(key, default)
+  end
 
-    Body:
-    * binary, char list or an iolist
-    * `{:form, [{K, V}, ...]}` - send a form url encoded
-    * `{:file, ~s(/path/to/file)}` - send a file
-    * `{:stream, enumerable}` - lazily send a stream of binaries/charlists
+  # take demand events from the queue
+  defp take_from_queue(queue, 0, events) do
+    {events, queue}
+  end
 
-    Options:
-    * `:result_timeout` - receive result timeout, in milliseconds. Default is 2 minutes
-    * `:timeout` - timeout to establish a connection, in milliseconds. Default is 8000
-    * `:recv_timeout` - timeout used when receiving a connection. Default is 5000
-    * `:proxy` - a proxy to be used for the request; it can be a regular url
-      or a `{Host, Port}` tuple
-    * `:proxy_auth` - proxy authentication `{User, Password}` tuple
-    * `:ssl` - SSL options supported by the `ssl` erlang module
-    * `:follow_redirect` - a boolean that causes redirects to be followed
-    * `:max_redirect` - an integer denoting the maximum number of redirects to follow
-    * `:params` - an enumerable consisting of two-item tuples that will be appended to the url as query string parameters
+  defp take_from_queue(queue, demand, events) do
+    case :queue.out(queue) do
+      {{:value, {kind, from, event}}, queue} ->
+        take_from_queue(queue, demand - 1, [{kind, from, event} | events])
 
-    Timeouts can be an integer or `:infinity`
-
-    This function returns `{:ok, response}` or `{:ok, async_response}` if the
-    request is successful, `{:error, reason}` otherwise.
-
-    ## Examples
-
-      request(:post, ~s(https://my.website.com), ~s({\"foo\": 3}), [{"Accept", "application/json"}])
-
-    """
-    @spec request(atom, binary, HTTPoison.body, HTTPoison.headers, Keyword.t) :: {:ok, HTTPoison.Response.t} | {:error, binary} | no_return
-    def request(method, url, body \\ "", headers \\ [], options \\ []) do
-        request = %RequestParams{
-          method: method,
-          url: url,
-          body: body,
-          headers: headers,
-          options: options
-        }
-        case options[:result_timeout] || config(:result_timeout) do
-          nil ->
-            GenStage.call(__MODULE__, {:request, request})
-          result_timeout ->
-            GenStage.call(__MODULE__, {:request, request}, result_timeout)
-        end
+      {:empty, queue} ->
+        take_from_queue(queue, 0, events)
     end
-
-    @doc ~S"""
-    Starts a task with request that must be awaited on.
-    """
-    @spec request_async(atom, binary, HTTPoison.body, HTTPoison.headers, Keyword.t) :: Task.t
-    def request_async(method, url, body \\ "", headers \\ [], options \\ []) do
-        Task.async(GSS.Client, :request, [method, url, body, headers, options])
-    end
-
-    ## Callbacks
-
-    def init(:ok) do
-        dispatcer = {GenStage.PartitionDispatcher, partitions: [:write, :read], hash: &dispatcher_hash/1}
-        {:producer, :queue.new(), dispatcher: dispatcer}
-    end
-
-    @doc ~S"""
-    Divide request into to partitions :read and :write
-    """
-    @spec dispatcher_hash(event) :: {event, partition()}
-    def dispatcher_hash({:request, _from, request} = event) do
-        case request.method do
-            :get -> {event, :read}
-            _ -> {event, :write}
-        end
-    end
-
-    @doc ~S"""
-    Adds an event to the queue
-    """
-    def handle_call({:request, request}, from, queue) do
-        updated_queue  = :queue.in({:request, from, request}, queue)
-        {:noreply, [], updated_queue}
-    end
-
-    @doc ~S"""
-    Gives events for the next stage to process when requested
-    """
-    def handle_demand(demand, queue) when demand > 0 do
-        {events, updated_queue} = take_from_queue(queue, demand, [])
-        {:noreply, Enum.reverse(events), updated_queue}
-    end
-
-
-    @doc """
-    Read config settings scoped for GSS client.
-    """
-    @spec config(atom(), any()) :: any()
-    def config(key, default \\ nil) do
-      Application.get_env(:elixir_google_spreadsheets, :client)
-      |> Keyword.get(key, default)
-    end
-
-    # take demand events from the queue
-    defp take_from_queue(queue, 0, events) do
-        {events, queue}
-    end
-    defp take_from_queue(queue, demand, events) do
-        case :queue.out(queue) do
-            {{:value, {kind, from, event}}, queue} ->
-                take_from_queue(queue, demand - 1, [{kind, from, event} | events])
-            {:empty, queue} ->
-                take_from_queue(queue, 0, events)
-        end
-    end
+  end
 end

--- a/lib/elixir_google_spreadsheets/client/limiter.ex
+++ b/lib/elixir_google_spreadsheets/client/limiter.ex
@@ -1,148 +1,151 @@
 defmodule GSS.Client.Limiter do
-    @moduledoc """
-    Model of Limiter request subscribed to Client with partition :write or :read
+  @moduledoc """
+  Model of Limiter request subscribed to Client with partition :write or :read
 
-    This process is a ProducerConsumer for this GenStage pipeline.
-    """
+  This process is a ProducerConsumer for this GenStage pipeline.
+  """
 
-    use GenStage
-    require Logger
+  use GenStage
+  require Logger
 
-    @type state :: %__MODULE__{
-            max_demand: pos_integer(),
-            max_interval: timeout(),
-            producer: GenStage.from(),
-            scheduled_at: pos_integer() | nil,
-            taked_events: pos_integer(),
-            interval: timeout()
-    }
-    defstruct [:max_demand, :max_interval, :producer,
-               :scheduled_at, :taked_events, :interval]
-
-    @type options :: [
-        name: atom(),
-        max_demand: pos_integer() | nil,
-        max_interval: timeout() | nil,
-        interval: timeout() | nil,
-        clients: [{atom(), keyword()} | atom()]
-    ]
-
-    @doc """
-    Starts an limiter manager linked to the current process.
-
-    If the event manager is successfully created and initialized, the function
-    returns {:ok, pid}, where pid is the PID of the server. If a process with the
-    specified server name already exists, the function returns {:error,
-    {:already_started, pid}} with the PID of that process.
-
-    ## Options
-    * `:name` - used for name registration as described in the "Name
-    registration" section of the module documentation
-    * `:interval` - ask new events from producer after `:interval` milliseconds.
-    * `:max_demand` - count of maximum requests per `:maximum_interval`
-    * `:max_interval` - maximum time that allowed in `:max_demand` requests
-    * `:clients` - list of clients with partition options. For example `[{GSS.Client, partition: :read}}]`.
-    """
-    @spec start_link(options()) :: GenServer.on_start()
-    def start_link(options \\ []) do
-        GenStage.start_link(__MODULE__, options, name: Keyword.get(options, :name))
-    end
-
-    ## Callbacks
-
-    def init(args) do
-        Logger.debug "init: #{inspect args}"
-
-        state = %__MODULE__{
-            max_demand: args[:max_demand] || 100,
-            max_interval: args[:max_interval] || 1_000,
-            interval: args[:interval] || 100,
-            taked_events: 0,
-            scheduled_at: nil
+  @type state :: %__MODULE__{
+          max_demand: pos_integer(),
+          max_interval: timeout(),
+          producer: GenStage.from(),
+          scheduled_at: pos_integer() | nil,
+          taked_events: pos_integer(),
+          interval: timeout()
         }
-        Process.send_after(self(), :ask, 0)
+  defstruct [:max_demand, :max_interval, :producer, :scheduled_at, :taked_events, :interval]
 
-        {:producer_consumer, state, subscribe_to: args[:clients]}
+  @type options :: [
+          name: atom(),
+          max_demand: pos_integer() | nil,
+          max_interval: timeout() | nil,
+          interval: timeout() | nil,
+          clients: [{atom(), keyword()} | atom()]
+        ]
+
+  @doc """
+  Starts an limiter manager linked to the current process.
+
+  If the event manager is successfully created and initialized, the function
+  returns {:ok, pid}, where pid is the PID of the server. If a process with the
+  specified server name already exists, the function returns {:error,
+  {:already_started, pid}} with the PID of that process.
+
+  ## Options
+  * `:name` - used for name registration as described in the "Name
+  registration" section of the module documentation
+  * `:interval` - ask new events from producer after `:interval` milliseconds.
+  * `:max_demand` - count of maximum requests per `:maximum_interval`
+  * `:max_interval` - maximum time that allowed in `:max_demand` requests
+  * `:clients` - list of clients with partition options. For example `[{GSS.Client, partition: :read}}]`.
+  """
+  @spec start_link(options()) :: GenServer.on_start()
+  def start_link(options \\ []) do
+    GenStage.start_link(__MODULE__, options, name: Keyword.get(options, :name))
+  end
+
+  ## Callbacks
+
+  def init(args) do
+    Logger.debug("init: #{inspect(args)}")
+
+    state = %__MODULE__{
+      max_demand: args[:max_demand] || 100,
+      max_interval: args[:max_interval] || 1_000,
+      interval: args[:interval] || 100,
+      taked_events: 0,
+      scheduled_at: nil
+    }
+
+    Process.send_after(self(), :ask, 0)
+
+    {:producer_consumer, state, subscribe_to: args[:clients]}
+  end
+
+  # Set the subscription to manual to control when to ask for events
+  def handle_subscribe(:producer, _options, from, state) do
+    {:manual, Map.put(state, :producer, from)}
+  end
+
+  # Make the subscriptions to auto for consumers
+  def handle_subscribe(:consumer, _, _, state) do
+    {:automatic, state}
+  end
+
+  def handle_events(events, _from, state) do
+    Logger.debug(fn -> "Limiter Handle events: #{inspect(events)}" end)
+
+    state =
+      state
+      |> Map.update!(:taked_events, &(&1 + length(events)))
+      |> schedule_counts()
+
+    {:noreply, events, state}
+  end
+
+  @doc ~S"""
+  Gives events for the next stage to process when requested
+  """
+  def handle_demand(demand, state) when demand > 0 do
+    {:noreply, [], state}
+  end
+
+  @doc ~S"""
+  Ask new events if needed
+  """
+  def handle_info(:ask, state) do
+    {:noreply, [], ask_and_schedule(state)}
+  end
+
+  @doc ~S"""
+  Check to reach limit.
+
+  If limit not reached ask again after `:interval` timeout,
+  otherwise ask after `:max_interval` timeout.
+  """
+  def ask_and_schedule(state) do
+    cond do
+      limited_events?(state) ->
+        Process.send_after(self(), :ask, state.max_interval)
+        clear_counts(state)
+
+      interval_expired?(state) ->
+        GenStage.ask(state.producer, state.max_demand)
+        Process.send_after(self(), :ask, state.interval)
+        clear_counts(state)
+
+      true ->
+        GenStage.ask(state.producer, state.max_demand)
+        Process.send_after(self(), :ask, state.interval)
+
+        schedule_counts(state)
     end
+  end
 
-    # Set the subscription to manual to control when to ask for events
-    def handle_subscribe(:producer, _options, from, state) do
-        {:manual, Map.put(state, :producer, from)}
-    end
+  # take events more than max demand
+  defp limited_events?(state) do
+    state.taked_events >= state.max_demand
+  end
 
-    # Make the subscriptions to auto for consumers
-    def handle_subscribe(:consumer, _, _, state) do
-        {:automatic, state}
-    end
+  # check limit of interval
+  defp interval_expired?(%__MODULE__{scheduled_at: nil}), do: false
 
-    def handle_events(events, _from, state) do
-        Logger.debug fn -> "Limiter Handle events: #{inspect events}" end
+  defp interval_expired?(%__MODULE__{scheduled_at: scheduled_at, max_interval: max_interval}) do
+    now = :erlang.timestamp()
+    :timer.now_diff(now, scheduled_at) >= max_interval * 1000
+  end
 
-        state = state
-        |> Map.update!(:taked_events, &(&1 + length(events)))
-        |> schedule_counts()
+  defp clear_counts(state) do
+    %{state | taked_events: 0, scheduled_at: nil}
+  end
 
-        {:noreply, events, state}
-    end
+  # set current timestamp to scheduled_at
+  defp schedule_counts(%__MODULE__{scheduled_at: nil} = state) do
+    %{state | scheduled_at: :erlang.timestamp()}
+  end
 
-    @doc ~S"""
-    Gives events for the next stage to process when requested
-    """
-    def handle_demand(demand, state) when demand > 0 do
-        {:noreply, [], state}
-    end
-
-    @doc ~S"""
-    Ask new events if needed
-    """
-    def handle_info(:ask, state) do
-        {:noreply, [], ask_and_schedule(state)}
-    end
-
-    @doc ~S"""
-    Check to reach limit.
-
-    If limit not reached ask again after `:interval` timeout,
-    otherwise ask after `:max_interval` timeout.
-    """
-    def ask_and_schedule(state) do
-        cond do
-            limited_events?(state) ->
-                Process.send_after(self(), :ask, state.max_interval)
-                clear_counts(state)
-
-            interval_expired?(state) ->
-                GenStage.ask(state.producer, state.max_demand)
-                Process.send_after(self(), :ask, state.interval)
-                clear_counts(state)
-
-            true ->
-                GenStage.ask(state.producer, state.max_demand)
-                Process.send_after(self(), :ask, state.interval)
-
-                schedule_counts(state)
-        end
-    end
-
-    # take events more than max demand
-    defp limited_events?(state) do
-        state.taked_events >= state.max_demand
-    end
-
-    # check limit of interval
-    defp interval_expired?(%__MODULE__{scheduled_at: nil}), do: false
-    defp interval_expired?(%__MODULE__{scheduled_at: scheduled_at, max_interval: max_interval}) do
-        now = :erlang.timestamp()
-        :timer.now_diff(now, scheduled_at) >= max_interval * 1000
-    end
-
-    defp clear_counts(state) do
-          %{state | taked_events: 0, scheduled_at: nil}
-    end
-
-    # set current timestamp to scheduled_at
-    defp schedule_counts(%__MODULE__{scheduled_at: nil} = state) do
-        %{state | scheduled_at: :erlang.timestamp()}
-    end
-    defp schedule_counts(state), do: state
+  defp schedule_counts(state), do: state
 end

--- a/lib/elixir_google_spreadsheets/client/request.ex
+++ b/lib/elixir_google_spreadsheets/client/request.ex
@@ -1,80 +1,85 @@
 defmodule GSS.Client.Request do
-    @moduledoc """
-    Worker of Request subscribed to Limiter, call request to API and send an answer to Client.
-    """
+  @moduledoc """
+  Worker of Request subscribed to Limiter, call request to API and send an answer to Client.
+  """
 
-    use GenStage
-    require Logger
+  use GenStage
+  require Logger
 
-    alias GSS.{Client, Client.RequestParams}
+  alias GSS.{Client, Client.RequestParams}
 
-    @type state :: :ok
+  @type state :: :ok
 
-   @type options :: [
-        name: atom() | nil,
-        limiters: [{atom(), keyword()} | atom()]
-    ]
+  @type options :: [
+          name: atom() | nil,
+          limiters: [{atom(), keyword()} | atom()]
+        ]
 
-    @doc """
-    Starts an request worker linked to the current process.
-    Takes events from Limiter and send requests through HTTPoison
+  @doc """
+  Starts an request worker linked to the current process.
+  Takes events from Limiter and send requests through HTTPoison
 
-    ## Options
-    * `:name` - used for name registration as described in the "Name registration" section of the module documentation. Default is `#{__MODULE__}`
-    * `:limiters` - list of limiters with max_demand options. For example `[{#{Client.Limiter}, max_demand: 1}]`.
-    """
-    @spec start_link(options()) :: GenServer.on_start()
-    def start_link(args) do
-        GenStage.start_link(__MODULE__, args, name: args[:name] || __MODULE__)
+  ## Options
+  * `:name` - used for name registration as described in the "Name registration" section of the module documentation. Default is `#{
+    __MODULE__
+  }`
+  * `:limiters` - list of limiters with max_demand options. For example `[{#{Client.Limiter}, max_demand: 1}]`.
+  """
+  @spec start_link(options()) :: GenServer.on_start()
+  def start_link(args) do
+    GenStage.start_link(__MODULE__, args, name: args[:name] || __MODULE__)
+  end
+
+  ## Callbacks
+
+  def init(args) do
+    Logger.debug("Request init: #{inspect(args)}")
+    {:consumer, :ok, subscribe_to: args[:limiters]}
+  end
+
+  @doc ~S"""
+  Set the subscription to manual to control when to ask for events
+  """
+  def handle_subscribe(:producer, _options, _from, state) do
+    {:automatic, state}
+  end
+
+  @spec handle_events([Client.event()], GenStage.from(), state()) :: {:noreply, [], state()}
+  def handle_events([{:request, from, request}], _from, state) do
+    Logger.debug("Request handle events: #{inspect(request)}")
+
+    response = send_request(request)
+    Logger.debug("Response #{inspect(response)}")
+    GenStage.reply(from, response)
+
+    {:noreply, [], state}
+  end
+
+  @spec send_request(RequestParams.t()) :: {:ok, HTTPoison.Response.t()} | {:error, binary()}
+  defp send_request(request) do
+    %RequestParams{
+      method: method,
+      url: url,
+      body: body,
+      headers: headers,
+      options: options
+    } = request
+
+    Logger.debug("send_request #{url}")
+
+    try do
+      case HTTPoison.request(method, url, body, headers, options || []) do
+        {:ok, response} ->
+          {:ok, response}
+
+        {:error, %HTTPoison.Error{reason: reason}} ->
+          Logger.error("Request poison error #{inspect(reason)}: #{inspect(request)}")
+          {:error, reason}
+      end
+    rescue
+      error ->
+        Logger.error("Request error exception #{inspect(error)}: #{inspect(request)}")
+        {:error, error}
     end
-
-    ## Callbacks
-
-    def init(args) do
-        Logger.debug "Request init: #{inspect args}"
-        {:consumer, :ok, subscribe_to: args[:limiters]}
-    end
-
-    @doc ~S"""
-    Set the subscription to manual to control when to ask for events
-    """
-    def handle_subscribe(:producer, _options, _from, state) do
-        {:automatic, state}
-    end
-
-    @spec handle_events([Client.event()], GenStage.from(), state()) :: {:noreply, [], state()}
-    def handle_events([{:request, from, request}], _from, state) do
-        Logger.debug "Request handle events: #{inspect request}"
-
-        response = send_request(request)
-        Logger.debug "Response #{inspect response}"
-        GenStage.reply(from, response)
-
-        {:noreply, [], state}
-    end
-
-    @spec send_request(RequestParams.t) :: {:ok, HTTPoison.Response.t} | {:error, binary()}
-    defp send_request(request) do
-       %RequestParams{
-            method: method,
-            url: url,
-            body: body,
-            headers: headers,
-            options: options
-        } = request
-        Logger.debug "send_request #{url}"
-        try do
-            case HTTPoison.request(method, url, body, headers, options || []) do
-                {:ok, response} ->
-                    {:ok, response}
-                {:error, %HTTPoison.Error{reason: reason}} ->
-                    Logger.error "Request poison error #{inspect reason}: #{inspect request}"
-                    {:error, reason}
-            end
-        rescue
-            error ->
-                Logger.error "Request error exception #{inspect error}: #{inspect request}"
-                {:error, error}
-        end
-    end
+  end
 end

--- a/lib/elixir_google_spreadsheets/client/supervisor.ex
+++ b/lib/elixir_google_spreadsheets/client/supervisor.ex
@@ -1,48 +1,56 @@
 defmodule GSS.Client.Supervisor do
-    @moduledoc """
-    Supervisor to keep track of initialized Client, Limiter and Request processes.
-    """
+  @moduledoc """
+  Supervisor to keep track of initialized Client, Limiter and Request processes.
+  """
 
-    use Supervisor
-    alias GSS.{Client, Client.Limiter, Client.Request}
+  use Supervisor
+  alias GSS.{Client, Client.Limiter, Client.Request}
 
-    @spec start_link() :: {:ok, pid}
-    def start_link do
-       Supervisor.start_link(__MODULE__, [],  name: __MODULE__)
-    end
+  @spec start_link() :: {:ok, pid}
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
 
-    @spec init([]) :: {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}} | :ignore
-    def init([]) do
-        config = Application.fetch_env!(:elixir_google_spreadsheets, :client)
-        limiter_args = Keyword.take(config, [:max_demand, :interval, :max_interval])
+  @spec init([]) :: {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}} | :ignore
+  def init([]) do
+    config = Application.fetch_env!(:elixir_google_spreadsheets, :client)
+    limiter_args = Keyword.take(config, [:max_demand, :interval, :max_interval])
 
-        children = [
-            worker(Client, []),
-            worker(Limiter, [
-                limiter_args
-                |> Keyword.put(:clients, [{Client, partition: :write}])
-                |> Keyword.put(:name, Limiter.Writer)
-            ], id: Limiter.Writer),
-            worker(Limiter, [
-                limiter_args
-                |> Keyword.put(:partition, :read)
-                |> Keyword.put(:clients, [{Client, partition: :read}])
-                |> Keyword.put(:name, Limiter.Reader)
-            ], id: Limiter.Reader)
-        ]
+    children = [
+      worker(Client, []),
+      worker(
+        Limiter,
+        [
+          limiter_args
+          |> Keyword.put(:clients, [{Client, partition: :write}])
+          |> Keyword.put(:name, Limiter.Writer)
+        ],
+        id: Limiter.Writer
+      ),
+      worker(
+        Limiter,
+        [
+          limiter_args
+          |> Keyword.put(:partition, :read)
+          |> Keyword.put(:clients, [{Client, partition: :read}])
+          |> Keyword.put(:name, Limiter.Reader)
+        ],
+        id: Limiter.Reader
+      )
+    ]
 
-        request_workers =
-            for num <- 1..Keyword.get(config, :request_workers, 10),
-            {limiter, name} <- [{Limiter.Writer, Request.Write}, {Limiter.Reader, Request.Read}]
-            do
-                name = :"#{name}#{num}"
-                worker(
-                    Request,
-                    [[name: name, limiters: [{limiter, max_demand: 1}]]],
-                    id: name
-                )
-            end
+    request_workers =
+      for num <- 1..Keyword.get(config, :request_workers, 10),
+          {limiter, name} <- [{Limiter.Writer, Request.Write}, {Limiter.Reader, Request.Read}] do
+        name = :"#{name}#{num}"
 
-        supervise(children ++ request_workers, strategy: :one_for_one)
-    end
+        worker(
+          Request,
+          [[name: name, limiters: [{limiter, max_demand: 1}]]],
+          id: name
+        )
+      end
+
+    supervise(children ++ request_workers, strategy: :one_for_one)
+  end
 end

--- a/lib/elixir_google_spreadsheets/exceptions.ex
+++ b/lib/elixir_google_spreadsheets/exceptions.ex
@@ -1,27 +1,27 @@
 defmodule GSS.GoogleApiError do
-    @moduledoc """
-    Raised in case non 200 response code from Google Cloud API.
-    """
-    defexception [:message]
+  @moduledoc """
+  Raised in case non 200 response code from Google Cloud API.
+  """
+  defexception [:message]
 end
 
 defmodule GSS.InvalidColumnIndex do
-    @moduledoc """
-    Raised in case more than 255 columns is queried.
-    """
-    defexception [:message]
+  @moduledoc """
+  Raised in case more than 255 columns is queried.
+  """
+  defexception [:message]
 end
 
 defmodule GSS.InvalidRange do
-    @moduledoc """
-    Raised in case invalid range is defined.
-    """
-    defexception [:message]
+  @moduledoc """
+  Raised in case invalid range is defined.
+  """
+  defexception [:message]
 end
 
 defmodule GSS.InvalidInput do
-    @moduledoc """
-    Raised in case invalid input params are passed
-    """
-    defexception [:message]
+  @moduledoc """
+  Raised in case invalid input params are passed
+  """
+  defexception [:message]
 end

--- a/lib/elixir_google_spreadsheets/registry.ex
+++ b/lib/elixir_google_spreadsheets/registry.ex
@@ -1,121 +1,131 @@
 defmodule GSS.Registry do
-    @moduledoc """
-    Google spreadsheets core authorization.
-    Automatically updates access token after expiration.
-    """
+  @moduledoc """
+  Google spreadsheets core authorization.
+  Automatically updates access token after expiration.
+  """
 
-    use GenServer
+  use GenServer
 
-    @typedoc """
-    State of Google Cloud API :
+  @typedoc """
+  State of Google Cloud API :
+      %{
+          auth: %Goth.Token{
+              expires: 1453356568,
+              token: "ya29.cALlJ4HHWRvMkYB-WsAR-CZnexE459yA7QPqKg3nei1y2T7-iqmbcgxb8XrTATNn_Blim",
+              type: "Bearer"
+          }
+      }
+  """
+  @type state :: map()
+
+  @auth_scope "https://www.googleapis.com/auth/spreadsheets"
+
+  @spec start_link() :: {:ok, pid}
+  def start_link do
+    initial_state = %{
+      active_sheets: %{}
+    }
+
+    GenServer.start_link(__MODULE__, initial_state, name: __MODULE__)
+  end
+
+  @spec init(state) :: {:ok, state}
+  def init(state) do
+    {:ok, state}
+  end
+
+  @doc """
+  Get account authorization token.
+  """
+  @spec token() :: String.t()
+  def token do
+    GenServer.call(__MODULE__, :token)
+  end
+
+  @doc """
+  Add or replace Google Spreadsheet in a registry.
+  """
+  @spec new_spreadsheet(String.t(), pid, Keyword.t()) :: :ok
+  def new_spreadsheet(spreadsheet_id, pid, opts \\ []) do
+    GenServer.call(__MODULE__, {:new_spreadsheet, spreadsheet_id, pid, opts})
+  end
+
+  @doc """
+  Fetch Google Spreadsheet proccess by it's id in the registry.
+  """
+  @spec spreadsheet_pid(String.t(), Keyword.t()) :: pid
+  def spreadsheet_pid(spreadsheet_id, opts \\ []) do
+    GenServer.call(__MODULE__, {:spreadsheet_pid, spreadsheet_id, opts})
+  end
+
+  @doc """
+  Get account authorization token, issue new token in case old has expired.
+  """
+  def handle_call(
+        :token,
+        _from,
         %{
-            auth: %Goth.Token{
-                expires: 1453356568,
-                token: "ya29.cALlJ4HHWRvMkYB-WsAR-CZnexE459yA7QPqKg3nei1y2T7-iqmbcgxb8XrTATNn_Blim",
-                type: "Bearer"
-            }
-        }
-    """
-    @type state :: map()
-
-    @auth_scope "https://www.googleapis.com/auth/spreadsheets"
-
-
-    @spec start_link() :: {:ok, pid}
-    def start_link do
-        initial_state = %{
-            active_sheets: %{}
-        }
-        GenServer.start_link(__MODULE__, initial_state, name: __MODULE__)
+          auth: %{
+            token: token,
+            expires: expires
+          }
+        } = state
+      ) do
+    if expires < :os.system_time(:seconds) do
+      new_state = Map.put(state, :auth, refresh_token())
+      {:reply, new_state.auth.token, new_state}
+    else
+      {:reply, token, state}
     end
+  end
 
-    @spec init(state) :: {:ok, state}
-    def init(state) do
-        {:ok, state}
-    end
+  def handle_call(:token, _from, state) do
+    new_state = Map.put(state, :auth, refresh_token())
+    {:reply, new_state.auth.token, new_state}
+  end
 
-    @doc """
-    Get account authorization token.
-    """
-    @spec token() :: String.t
-    def token do
-        GenServer.call(__MODULE__, :token)
-    end
-
-    @doc """
-    Add or replace Google Spreadsheet in a registry.
-    """
-    @spec new_spreadsheet(String.t, pid, Keyword.t) :: :ok
-    def new_spreadsheet(spreadsheet_id, pid, opts \\ []) do
-        GenServer.call(__MODULE__, {:new_spreadsheet, spreadsheet_id, pid, opts})
-    end
-
-    @doc """
-    Fetch Google Spreadsheet proccess by it's id in the registry.
-    """
-    @spec spreadsheet_pid(String.t, Keyword.t) :: pid
-    def spreadsheet_pid(spreadsheet_id, opts \\ []) do
-        GenServer.call(__MODULE__, {:spreadsheet_pid, spreadsheet_id, opts})
-    end
-
-    @doc """
-    Get account authorization token, issue new token in case old has expired.
-    """
-    def handle_call(:token, _from, %{auth: %{
-        token: token,
-        expires: expires
-    }} = state) do
-        if (expires < :os.system_time(:seconds)) do
-            new_state = Map.put(state, :auth, refresh_token())
-            {:reply, new_state.auth.token, new_state}
-        else
-            {:reply, token, state}
-        end
-    end
-    def handle_call(:token, _from, state) do
-        new_state = Map.put(state, :auth, refresh_token())
-        {:reply, new_state.auth.token, new_state}
-    end
-
-    @doc """
-    Update :active_sheets registry record.
-    """
-    def handle_call(
+  @doc """
+  Update :active_sheets registry record.
+  """
+  def handle_call(
         {:new_spreadsheet, spreadsheet_id, pid, opts},
         _from,
         %{active_sheets: active_sheets} = state
-    ) when is_bitstring(spreadsheet_id) and is_pid(pid) do
-        registry_id = id(spreadsheet_id, opts)
-        new_active_sheets = Map.put(active_sheets, registry_id, pid)
-        new_state = Map.put(state, :active_sheets, new_active_sheets)
-        {:reply, :ok, new_state}
-    end
+      )
+      when is_bitstring(spreadsheet_id) and is_pid(pid) do
+    registry_id = id(spreadsheet_id, opts)
+    new_active_sheets = Map.put(active_sheets, registry_id, pid)
+    new_state = Map.put(state, :active_sheets, new_active_sheets)
+    {:reply, :ok, new_state}
+  end
 
-    @doc """
-    Get pid of sheet in :active_sheets registry.
-    """
-    def handle_call(
+  @doc """
+  Get pid of sheet in :active_sheets registry.
+  """
+  def handle_call(
         {:spreadsheet_pid, spreadsheet_id, opts},
         _from,
         %{active_sheets: active_sheets} = state
-    ) when is_bitstring(spreadsheet_id) do
-        registry_id = id(spreadsheet_id, opts)
-        {:reply, Map.get(active_sheets, registry_id, nil), state}
-    end
+      )
+      when is_bitstring(spreadsheet_id) do
+    registry_id = id(spreadsheet_id, opts)
+    {:reply, Map.get(active_sheets, registry_id, nil), state}
+  end
 
-    @spec refresh_token() :: map()
-    defp refresh_token do
-        {:ok, token} = Goth.Token.for_scope(@auth_scope)
-        token
-    end
+  @spec refresh_token() :: map()
+  defp refresh_token do
+    {:ok, token} = Goth.Token.for_scope(@auth_scope)
+    token
+  end
 
-    @spec id(String.t, Keyword.t) :: String.t
-    defp id(spreadsheet_id, opts) do
-        list_name = Keyword.get(opts, :list_name)
-        if is_bitstring(list_name) do
-            "#{spreadsheet_id}!#{list_name}"
-        else
-            spreadsheet_id
-        end
+  @spec id(String.t(), Keyword.t()) :: String.t()
+  defp id(spreadsheet_id, opts) do
+    list_name = Keyword.get(opts, :list_name)
+
+    if is_bitstring(list_name) do
+      "#{spreadsheet_id}!#{list_name}"
+    else
+      spreadsheet_id
     end
+  end
 end

--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -1,614 +1,698 @@
 defmodule GSS.Spreadsheet do
-    @moduledoc """
-    Model of Google Spreadsheet for external interaction.
-    """
+  @moduledoc """
+  Model of Google Spreadsheet for external interaction.
+  """
 
-    require Logger
-    use GenServer
-    alias GSS.Client
+  require Logger
+  use GenServer
+  alias GSS.Client
 
-    @typedoc """
-    State of currently active Google spreadsheet:
-        %{
-            spreadsheet_id => "16Wgt0fuoYDgEAtGtYKF4jdjAhZez0q77UhkKdeKI6B4",
-            list_name => nil
-        }
-    """
-    @type state :: map()
-    @type spreadsheet_data :: [String.t]
-    @type spreadsheet_response :: {:json, map()} | {:error, Exception.t} | no_return()
+  @typedoc """
+  State of currently active Google spreadsheet:
+      %{
+          spreadsheet_id => "16Wgt0fuoYDgEAtGtYKF4jdjAhZez0q77UhkKdeKI6B4",
+          list_name => nil
+      }
+  """
+  @type state :: map()
+  @type spreadsheet_data :: [String.t()]
+  @type spreadsheet_response :: {:json, map()} | {:error, Exception.t()} | no_return()
 
-    @api_url_spreadsheet "https://sheets.googleapis.com/v4/spreadsheets/"
-    @default_request_params [ssl: [{:versions, [:'tlsv1.2']}]]
-    @max_rows GSS.config(:max_rows_per_request, 301)
-    @default_column_from GSS.config(:default_column_from, 1)
-    @default_column_to GSS.config(:default_column_to, 26)
+  @api_url_spreadsheet "https://sheets.googleapis.com/v4/spreadsheets/"
+  @default_request_params [ssl: [{:versions, [:"tlsv1.2"]}]]
+  @max_rows GSS.config(:max_rows_per_request, 301)
+  @default_column_from GSS.config(:default_column_from, 1)
+  @default_column_to GSS.config(:default_column_to, 26)
 
-    @spec start_link(String.t, Keyword.t) :: {:ok, pid}
-    def start_link(spreadsheet_id, opts) do
-        GenServer.start_link(__MODULE__, {spreadsheet_id, opts}, Keyword.take(opts, [:name]))
+  @spec start_link(String.t(), Keyword.t()) :: {:ok, pid}
+  def start_link(spreadsheet_id, opts) do
+    GenServer.start_link(__MODULE__, {spreadsheet_id, opts}, Keyword.take(opts, [:name]))
+  end
+
+  @spec init({String.t(), Keyword.t()}) :: {:ok, state}
+  def init({spreadsheet_id, opts}) do
+    {:ok, %{spreadsheet_id: spreadsheet_id, list_name: Keyword.get(opts, :list_name)}}
+  end
+
+  @doc """
+  Get spreadsheet internal id.
+  """
+  @spec id(pid) :: String.t()
+  def id(pid) do
+    GenServer.call(pid, :id)
+  end
+
+  @doc """
+  Get spreadsheet properties.
+  """
+  @spec properties(pid) :: map()
+  def properties(pid) do
+    GenServer.call(pid, :properties)
+  end
+
+  @doc """
+  Get spreadsheet sheets from properties.
+  """
+  @spec sheets(pid, Keyword.t()) :: [map()] | map()
+  def sheets(pid, opts \\ []) do
+    with {:ok, %{"sheets" => sheets}} <- GenServer.call(pid, :properties),
+         {:is_raw_response?, false, _} <-
+           {:is_raw_response?, Keyword.get(opts, :raw, false), sheets} do
+      Enum.reduce(sheets, %{}, fn %{"properties" => %{"title" => title} = properties}, acc ->
+        Map.put(acc, title, properties)
+      end)
+    else
+      {:is_raw_response?, false, sheets} ->
+        sheets
+
+      _ ->
+        []
     end
+  end
 
-    @spec init({String.t, Keyword.t}) :: {:ok, state}
-    def init({spreadsheet_id, opts}) do
-        {:ok, %{spreadsheet_id: spreadsheet_id, list_name: Keyword.get(opts, :list_name)}}
+  @doc """
+  Get total amount of rows in a spreadsheet.
+  """
+  @spec rows(pid) :: {:ok, integer()} | {:error, Exception.t()}
+  def rows(pid) do
+    GenServer.call(pid, :rows)
+  end
+
+  @doc """
+  Granural read by a custom range from a spreadsheet.
+  """
+  @spec fetch(pid, String.t()) :: {:ok, spreadsheet_data} | {:error, Exception.t()}
+  def fetch(pid, range) do
+    GenServer.call(pid, {:fetch, range})
+  end
+
+  @doc """
+  Read row in a spreadsheet by index.
+  """
+  @spec read_row(pid, integer(), Keyword.t()) :: {:ok, spreadsheet_data} | {:error, Exception.t()}
+  def read_row(pid, row_index, options \\ []) do
+    gen_server_call(pid, {:read_row, row_index, options}, options)
+  end
+
+  @doc """
+  Override row in a spreadsheet by index.
+  """
+  @spec write_row(pid, integer(), spreadsheet_data, Keyword.t()) :: :ok
+  def write_row(pid, row_index, column_list, options \\ []) when is_list(column_list) do
+    gen_server_call(pid, {:write_row, row_index, column_list, options}, options)
+  end
+
+  @doc """
+  Append row in a spreadsheet after an index.
+  """
+  @spec append_row(pid, integer(), spreadsheet_data, Keyword.t()) :: :ok
+  def append_row(pid, row_index, column_list, options \\ []) when is_list(column_list) do
+    gen_server_call(pid, {:append_row, row_index, column_list, options}, options)
+  end
+
+  @doc """
+  Clear row in a spreadsheet by index.
+  """
+  @spec clear_row(pid, integer(), Keyword.t()) :: :ok
+  def clear_row(pid, row_index, options \\ []) do
+    gen_server_call(pid, {:clear_row, row_index, options}, options)
+  end
+
+  @doc """
+  Batched read, which returns more than one record.
+  Pass either an array of ranges (or rows), or start and end row indexes.
+
+  By default it returns `nils` for an empty rows,
+  use `pad_empty: true` and `column_to: integer` options to fill records
+  with an empty string values.
+  """
+  @spec read_rows(pid, [String.t()] | [integer()]) ::
+          {:ok, [spreadsheet_data | nil]} | {:error, Exception.t()}
+  def read_rows(pid, ranges), do: read_rows(pid, ranges, [])
+
+  @spec read_rows(pid, [String.t()] | [integer()], Keyword.t()) ::
+          {:ok, [spreadsheet_data]} | {:error, Exception.t()}
+  def read_rows(pid, ranges, options) when is_list(ranges) do
+    gen_server_call(pid, {:read_rows, ranges, options}, options)
+  end
+
+  @spec read_rows(pid, integer(), integer()) :: {:ok, [spreadsheet_data]} | {:error, atom}
+  def read_rows(pid, row_index_start, row_index_end)
+      when is_integer(row_index_start) and is_integer(row_index_end),
+      do: read_rows(pid, row_index_start, row_index_end, [])
+
+  def read_rows(_, _, _),
+    do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
+
+  @spec read_rows(pid, integer(), integer(), Keyword.t()) ::
+          {:ok, [spreadsheet_data]} | {:error, atom}
+  def read_rows(pid, row_index_start, row_index_end, options)
+      when is_integer(row_index_start) and is_integer(row_index_end) and
+             row_index_start < row_index_end do
+    gen_server_call(pid, {:read_rows, row_index_start, row_index_end, options}, options)
+  end
+
+  def read_rows(_, _, _, _),
+    do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
+
+  @doc """
+  Batched clear, which deletes more then one record.
+  Pass either an array of ranges, or start and end row indexes.
+  """
+  @spec clear_rows(pid, [String.t()]) :: :ok | {:error, Exception.t()}
+  def clear_rows(pid, ranges), do: clear_rows(pid, ranges, [])
+  @spec clear_rows(pid, [String.t()], Keyword.t()) :: :ok | {:error, Exception.t()}
+  def clear_rows(pid, ranges, options) when is_list(ranges) do
+    gen_server_call(pid, {:clear_rows, ranges, options}, options)
+  end
+
+  @spec clear_rows(pid, integer(), integer()) :: :ok | {:error, Exception.t()}
+  def clear_rows(pid, row_index_start, row_index_end)
+      when is_integer(row_index_start) and is_integer(row_index_end),
+      do: clear_rows(pid, row_index_start, row_index_end, [])
+
+  def clear_rows(_, _, _),
+    do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
+
+  @spec clear_rows(pid, integer(), integer(), Keyword.t()) :: :ok | {:error, Exception.t()}
+  def clear_rows(pid, row_index_start, row_index_end, options)
+      when is_integer(row_index_start) and is_integer(row_index_end) and
+             row_index_start < row_index_end do
+    gen_server_call(pid, {:clear_rows, row_index_start, row_index_end, options}, options)
+  end
+
+  def clear_rows(_, _, _, _),
+    do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
+
+  @doc """
+  Batch update to write multiple rows.
+
+  Range schema should define the same amount of rows as
+  amound of records in data and same amount of columns
+  as entries in data record.
+  """
+  @spec write_rows(pid, [String.t()], [spreadsheet_data]) :: {:ok, any()}
+  def write_rows(pid, ranges, data), do: write_rows(pid, ranges, data, [])
+  @spec write_rows(pid, [String.t()], [spreadsheet_data], Keyword.t()) :: :ok
+  def write_rows(pid, ranges, data, options)
+      when is_list(data) and is_list(ranges) and length(data) == length(ranges) do
+    gen_server_call(pid, {:write_rows, ranges, data, options}, options)
+  end
+
+  def write_rows(_, _, _, _),
+    do:
+      {:error,
+       %GSS.InvalidInput{
+         message: "invalid ranges or data, length of ranges and data lists should be the same"
+       }}
+
+  @doc """
+  Get shreadsheet id stored in this state.
+  Used mainly for testing purposes.
+  """
+  def handle_call(:id, _from, %{spreadsheet_id: spreadsheet_id} = state) do
+    {:reply, spreadsheet_id, state}
+  end
+
+  @doc """
+  Get the shreadsheet properties
+  """
+  def handle_call(:properties, _from, %{spreadsheet_id: spreadsheet_id} = state) do
+    query = spreadsheet_id
+
+    case spreadsheet_query(:get, query) do
+      {:json, properties} ->
+        {:reply, {:ok, properties}, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @doc """
-    Get spreadsheet internal id.
-    """
-    @spec id(pid) :: String.t
-    def id(pid) do
-        GenServer.call(pid, :id)
+  @doc """
+  Get total number of rows from spreadsheets.
+  """
+  def handle_call(:rows, _from, %{spreadsheet_id: spreadsheet_id} = state) do
+    query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}A1:B"
+
+    case spreadsheet_query(:get, query) do
+      {:json, %{"values" => values}} ->
+        {:reply, {:ok, length(values)}, state}
+
+      {:json, _} ->
+        {:reply, {:ok, 0}, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @doc """
-    Get spreadsheet properties.
-    """
-    @spec properties(pid) :: map()
-    def properties(pid) do
-        GenServer.call(pid, :properties)
+  @doc """
+  Fetch the given range of cells from the spreadsheet
+  """
+  def handle_call({:fetch, the_range}, _from, %{spreadsheet_id: spreadsheet_id} = state) do
+    query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}#{the_range}"
+
+    case spreadsheet_query(:get, query) do
+      {:json, %{"values" => values}} ->
+        {:reply, {:ok, values}, state}
+
+      {:json, _} ->
+        {:reply, {:ok, nil}, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @doc """
-    Get spreadsheet sheets from properties.
-    """
-    @spec sheets(pid, Keyword.t) :: [map()] | map()
-    def sheets(pid, opts \\ []) do
-        with \
-            {:ok, %{"sheets" => sheets}} <- GenServer.call(pid, :properties),
-            {:is_raw_response?, false, _} <- {:is_raw_response?, Keyword.get(opts, :raw, false), sheets}
-        do
-            Enum.reduce sheets, %{}, fn(%{"properties" => %{"title" => title} = properties}, acc) ->
-                Map.put(acc, title, properties)
-            end
-        else
-            {:is_raw_response?, false, sheets} ->
-                sheets
-            _ ->
-                []
-        end
-    end
-
-    @doc """
-    Get total amount of rows in a spreadsheet.
-    """
-    @spec rows(pid) :: {:ok, integer()} | {:error, Exception.t}
-    def rows(pid) do
-        GenServer.call(pid, :rows)
-    end
-
-    @doc """
-    Granural read by a custom range from a spreadsheet.
-    """
-    @spec fetch(pid, String.t) :: {:ok, spreadsheet_data} | {:error, Exception.t}
-    def fetch(pid, range) do
-        GenServer.call(pid, {:fetch, range})
-    end
-
-    @doc """
-    Read row in a spreadsheet by index.
-    """
-    @spec read_row(pid, integer(), Keyword.t) :: {:ok, spreadsheet_data} | {:error, Exception.t}
-    def read_row(pid, row_index, options \\ []) do
-      gen_server_call(pid, {:read_row, row_index, options}, options)
-    end
-
-    @doc """
-    Override row in a spreadsheet by index.
-    """
-    @spec write_row(pid, integer(), spreadsheet_data, Keyword.t) :: :ok
-    def write_row(pid, row_index, column_list, options \\ []) when is_list(column_list) do
-      gen_server_call(pid, {:write_row, row_index, column_list, options}, options)
-    end
-
-    @doc """
-    Append row in a spreadsheet after an index.
-    """
-    @spec append_row(pid, integer(), spreadsheet_data, Keyword.t) :: :ok
-    def append_row(pid, row_index, column_list, options \\ []) when is_list(column_list) do
-      gen_server_call(pid, {:append_row, row_index, column_list, options}, options)
-    end
-
-    @doc """
-    Clear row in a spreadsheet by index.
-    """
-    @spec clear_row(pid, integer(), Keyword.t) :: :ok
-    def clear_row(pid, row_index, options \\ []) do
-      gen_server_call(pid, {:clear_row, row_index, options}, options)
-    end
-
-    @doc """
-    Batched read, which returns more than one record.
-    Pass either an array of ranges (or rows), or start and end row indexes.
-
-    By default it returns `nils` for an empty rows,
-    use `pad_empty: true` and `column_to: integer` options to fill records
-    with an empty string values.
-    """
-    @spec read_rows(pid, [String.t] | [integer()]) :: {:ok, [spreadsheet_data | nil]} | {:error, Exception.t}
-    def read_rows(pid, ranges), do: read_rows(pid, ranges, [])
-    @spec read_rows(pid, [String.t] | [integer()], Keyword.t) :: {:ok, [spreadsheet_data]} | {:error, Exception.t}
-    def read_rows(pid, ranges, options) when is_list(ranges) do
-      gen_server_call(pid, {:read_rows, ranges, options}, options)
-    end
-    @spec read_rows(pid, integer(), integer()) :: {:ok, [spreadsheet_data]} | {:error, atom}
-    def read_rows(pid, row_index_start, row_index_end)
-    when is_integer(row_index_start) and is_integer(row_index_end), do: read_rows(pid, row_index_start, row_index_end, [])
-    def read_rows(_, _, _), do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
-    @spec read_rows(pid, integer(), integer(), Keyword.t) :: {:ok, [spreadsheet_data]} | {:error, atom}
-    def read_rows(pid, row_index_start, row_index_end, options)
-    when is_integer(row_index_start) and is_integer(row_index_end) and row_index_start < row_index_end do
-      gen_server_call(pid, {:read_rows, row_index_start, row_index_end, options}, options)
-    end
-    def read_rows(_, _, _, _), do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
-
-    @doc """
-    Batched clear, which deletes more then one record.
-    Pass either an array of ranges, or start and end row indexes.
-    """
-    @spec clear_rows(pid, [String.t]) :: :ok | {:error, Exception.t}
-    def clear_rows(pid, ranges), do: clear_rows(pid, ranges, [])
-    @spec clear_rows(pid, [String.t], Keyword.t) :: :ok | {:error, Exception.t}
-    def clear_rows(pid, ranges, options) when is_list(ranges) do
-      gen_server_call(pid, {:clear_rows, ranges, options}, options)
-    end
-    @spec clear_rows(pid, integer(), integer()) :: :ok | {:error, Exception.t}
-    def clear_rows(pid, row_index_start, row_index_end)
-    when is_integer(row_index_start) and is_integer(row_index_end), do: clear_rows(pid, row_index_start, row_index_end, [])
-    def clear_rows(_, _, _), do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
-    @spec clear_rows(pid, integer(), integer(), Keyword.t) :: :ok | {:error, Exception.t}
-    def clear_rows(pid, row_index_start, row_index_end, options)
-    when is_integer(row_index_start) and is_integer(row_index_end) and row_index_start < row_index_end do
-      gen_server_call(pid, {:clear_rows, row_index_start, row_index_end, options}, options)
-    end
-    def clear_rows(_, _, _, _), do: {:error, %GSS.InvalidInput{message: "invalid start or end row index"}}
-
-    @doc """
-    Batch update to write multiple rows.
-
-    Range schema should define the same amount of rows as
-    amound of records in data and same amount of columns
-    as entries in data record.
-    """
-    @spec write_rows(pid, [String.t], [spreadsheet_data]) :: {:ok, any()}
-    def write_rows(pid, ranges, data), do: write_rows(pid, ranges, data, [])
-    @spec write_rows(pid, [String.t], [spreadsheet_data], Keyword.t) :: :ok
-    def write_rows(pid, ranges, data, options)
-    when is_list(data) and is_list(ranges) and length(data) == length(ranges) do
-      gen_server_call(pid, {:write_rows, ranges, data, options}, options)
-    end
-    def write_rows(_, _, _, _), do: {:error, %GSS.InvalidInput{message: "invalid ranges or data, length of ranges and data lists should be the same"}}
-
-
-    @doc """
-    Get shreadsheet id stored in this state.
-    Used mainly for testing purposes.
-    """
-    def handle_call(:id, _from, %{spreadsheet_id: spreadsheet_id} = state) do
-      {:reply, spreadsheet_id, state}
-    end
-
-    @doc """
-    Get the shreadsheet properties
-    """
-    def handle_call(:properties, _from, %{spreadsheet_id: spreadsheet_id} = state) do
-      query = spreadsheet_id
-
-      case spreadsheet_query(:get, query) do
-        {:json, properties} ->
-          {:reply, {:ok, properties}, state}
-        {:error, exception} ->
-          {:reply, {:error, exception}, state}
-        end
-    end
-
-    @doc """
-    Get total number of rows from spreadsheets.
-    """
-    def handle_call(:rows, _from, %{spreadsheet_id: spreadsheet_id} = state) do
-        query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}A1:B"
-
-        case spreadsheet_query(:get, query) do
-            {:json, %{"values" => values}} ->
-                {:reply, {:ok, length(values)}, state}
-            {:json, _} ->
-                {:reply, {:ok, 0}, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
-    end
-
-    @doc """
-    Fetch the given range of cells from the spreadsheet
-    """
-    def handle_call({:fetch, the_range}, _from, %{spreadsheet_id: spreadsheet_id} = state) do
-        query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}#{the_range}"
-
-        case spreadsheet_query(:get, query) do
-            {:json, %{"values" => values}} ->
-                {:reply, {:ok, values}, state}
-            {:json, _} ->
-                {:reply, {:ok, nil}, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
-    end
-
-
-    @doc """
-    Get column value list for specific row from a spreadsheet.
-    """
-    def handle_call(
+  @doc """
+  Get column value list for specific row from a spreadsheet.
+  """
+  def handle_call(
         {:read_row, row_index, options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        major_dimension = Keyword.get(options, :major_dimension, "ROWS")
-        value_render_option = Keyword.get(options, :value_render_option, "FORMATTED_VALUE")
-        datetime_render_option = Keyword.get(options, :datetime_render_option, "FORMATTED_STRING")
+      ) do
+    major_dimension = Keyword.get(options, :major_dimension, "ROWS")
+    value_render_option = Keyword.get(options, :value_render_option, "FORMATTED_VALUE")
+    datetime_render_option = Keyword.get(options, :datetime_render_option, "FORMATTED_STRING")
 
-        column_from = Keyword.get(options, :column_from, @default_column_from)
-        column_to = Keyword.get(options, :column_to, @default_column_to)
-        range = range(row_index, row_index, column_from, column_to)
-        query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}#{range}" <>
-            "?majorDimension=#{major_dimension}&valueRenderOption=#{value_render_option}" <>
-            "&dateTimeRenderOption=#{datetime_render_option}"
+    column_from = Keyword.get(options, :column_from, @default_column_from)
+    column_to = Keyword.get(options, :column_to, @default_column_to)
+    range = range(row_index, row_index, column_from, column_to)
 
-        case spreadsheet_query(:get, query) do
-            {:json, %{"values" => [values]}} when length(values) >= column_to ->
-                {:reply, {:ok, values}, state}
-            {:json, %{"values" => [values]}} ->
-                pad_amount = column_to - length(values)
-                {:reply, {:ok, values ++ pad(pad_amount)}, state}
-            {:json, _} ->
-                {:reply, {:ok, pad(column_to)}, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
+    query =
+      "#{spreadsheet_id}/values/#{maybe_attach_list(state)}#{range}" <>
+        "?majorDimension=#{major_dimension}&valueRenderOption=#{value_render_option}" <>
+        "&dateTimeRenderOption=#{datetime_render_option}"
+
+    case spreadsheet_query(:get, query) do
+      {:json, %{"values" => [values]}} when length(values) >= column_to ->
+        {:reply, {:ok, values}, state}
+
+      {:json, %{"values" => [values]}} ->
+        pad_amount = column_to - length(values)
+        {:reply, {:ok, values ++ pad(pad_amount)}, state}
+
+      {:json, _} ->
+        {:reply, {:ok, pad(column_to)}, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @doc """
-    Write values in a specific row to a spreadsheet.
-    """
-    def handle_call(
+  @doc """
+  Write values in a specific row to a spreadsheet.
+  """
+  def handle_call(
         {:write_row, row_index, column_list, options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        value_input_option = Keyword.get(options, :value_input_option, "USER_ENTERED")
+      ) do
+    value_input_option = Keyword.get(options, :value_input_option, "USER_ENTERED")
 
-        write_cells_count = length(column_list)
-        column_from = Keyword.get(options, :column_from, 1)
-        column_to = Keyword.get(options, :column_to, column_from + write_cells_count - 1)
-        range = range(row_index, row_index, column_from, column_to, state)
-        query = "#{spreadsheet_id}/values/#{range}?valueInputOption=#{value_input_option}"
+    write_cells_count = length(column_list)
+    column_from = Keyword.get(options, :column_from, 1)
+    column_to = Keyword.get(options, :column_to, column_from + write_cells_count - 1)
+    range = range(row_index, row_index, column_from, column_to, state)
+    query = "#{spreadsheet_id}/values/#{range}?valueInputOption=#{value_input_option}"
 
-        case spreadsheet_query(:put, query, column_list, options ++ [range: range]) do
-          {:json, %{"updatedRows" => 1, "updatedColumns" => updated_columns}}
-          when updated_columns > 0 ->
-            {:reply, :ok, state}
-          {:error, exception} ->
-            {:reply, {:error, exception}, state}
-        end
+    case spreadsheet_query(:put, query, column_list, options ++ [range: range]) do
+      {:json, %{"updatedRows" => 1, "updatedColumns" => updated_columns}}
+      when updated_columns > 0 ->
+        {:reply, :ok, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @doc """
-    Insert row under some other row and write the column_list content there.
-    """
-    def handle_call(
+  @doc """
+  Insert row under some other row and write the column_list content there.
+  """
+  def handle_call(
         {:append_row, row_index, column_list, options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        value_input_option = Keyword.get(options, :value_input_option, "USER_ENTERED")
-        insert_data_option = Keyword.get(options, :insert_data_option, "INSERT_ROWS")
+      ) do
+    value_input_option = Keyword.get(options, :value_input_option, "USER_ENTERED")
+    insert_data_option = Keyword.get(options, :insert_data_option, "INSERT_ROWS")
 
-        write_cells_count = length(column_list)
-        column_from = Keyword.get(options, :column_from, 1)
-        column_to = Keyword.get(options, :column_to, column_from + write_cells_count - 1)
-        range = range(row_index, row_index, column_from, column_to, state)
-        query = "#{spreadsheet_id}/values/#{range}:append" <>
-            "?valueInputOption=#{value_input_option}&insertDataOption=#{insert_data_option}"
+    write_cells_count = length(column_list)
+    column_from = Keyword.get(options, :column_from, 1)
+    column_to = Keyword.get(options, :column_to, column_from + write_cells_count - 1)
+    range = range(row_index, row_index, column_from, column_to, state)
 
-        case spreadsheet_query(:post, query, column_list, options ++ [range: range]) do
-            {:json, %{"updates" => %{
-                "updatedRows" => 1, "updatedColumns" => updated_columns
-            }}} when updated_columns > 0 ->
-                {:reply, :ok, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
+    query =
+      "#{spreadsheet_id}/values/#{range}:append" <>
+        "?valueInputOption=#{value_input_option}&insertDataOption=#{insert_data_option}"
+
+    case spreadsheet_query(:post, query, column_list, options ++ [range: range]) do
+      {:json,
+       %{
+         "updates" => %{
+           "updatedRows" => 1,
+           "updatedColumns" => updated_columns
+         }
+       }}
+      when updated_columns > 0 ->
+        {:reply, :ok, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @doc """
-    Clear rows in spreadsheet by their index.
-    """
-    def handle_call(
+  @doc """
+  Clear rows in spreadsheet by their index.
+  """
+  def handle_call(
         {:clear_row, row_index, options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        column_from = Keyword.get(options, :column_from, @default_column_from)
-        column_to = Keyword.get(options, :column_to, @default_column_to)
-        range = range(row_index, row_index, column_from, column_to)
-        query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}#{range}:clear"
+      ) do
+    column_from = Keyword.get(options, :column_from, @default_column_from)
+    column_to = Keyword.get(options, :column_to, @default_column_to)
+    range = range(row_index, row_index, column_from, column_to)
+    query = "#{spreadsheet_id}/values/#{maybe_attach_list(state)}#{range}:clear"
 
-        case spreadsheet_query(:post, query) do
-            {:json, %{"clearedRange" => _}} ->
-                {:reply, :ok, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
+    case spreadsheet_query(:post, query) do
+      {:json, %{"clearedRange" => _}} ->
+        {:reply, :ok, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
+  @doc """
+  Get column value list for specific row from a spreadsheet.
+  """
+  def handle_call({:read_rows, [row | _] = rows, options}, from, state) when is_integer(row) do
+    column_from = Keyword.get(options, :column_from, @default_column_from)
+    column_to = Keyword.get(options, :column_to, @default_column_to)
 
-    @doc """
-    Get column value list for specific row from a spreadsheet.
-    """
-    def handle_call({:read_rows, [row | _] = rows, options}, from, state) when is_integer(row) do
-        column_from = Keyword.get(options, :column_from, @default_column_from)
-        column_to = Keyword.get(options, :column_to, @default_column_to)
-        ranges = Enum.map rows, fn(row_index) ->
-            range(row_index, row_index, column_from, column_to)
-        end
-        handle_call({:read_rows, ranges, options}, from, state)
-    end
-    def handle_call(
+    ranges =
+      Enum.map(rows, fn row_index ->
+        range(row_index, row_index, column_from, column_to)
+      end)
+
+    handle_call({:read_rows, ranges, options}, from, state)
+  end
+
+  def handle_call(
         {:read_rows, ranges, options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        major_dimension = Keyword.get(options, :major_dimension, "ROWS")
-        value_render_option = Keyword.get(options, :value_render_option, "FORMATTED_VALUE")
-        datetime_render_option = Keyword.get(options, :datetime_render_option, "FORMATTED_STRING")
-        batched_ranges = Keyword.get(options, :batched_ranges, ranges)
+      ) do
+    major_dimension = Keyword.get(options, :major_dimension, "ROWS")
+    value_render_option = Keyword.get(options, :value_render_option, "FORMATTED_VALUE")
+    datetime_render_option = Keyword.get(options, :datetime_render_option, "FORMATTED_STRING")
+    batched_ranges = Keyword.get(options, :batched_ranges, ranges)
 
-        str_ranges = batched_ranges
-        |> Enum.map(&({:ranges, "#{maybe_attach_list(state)}#{&1}"}))
-        |> URI.encode_query
-        query = "#{spreadsheet_id}/values:batchGet" <>
-            "?majorDimension=#{major_dimension}&valueRenderOption=#{value_render_option}" <>
-            "&dateTimeRenderOption=#{datetime_render_option}&#{str_ranges}"
+    str_ranges =
+      batched_ranges
+      |> Enum.map(&{:ranges, "#{maybe_attach_list(state)}#{&1}"})
+      |> URI.encode_query()
 
-        case spreadsheet_query(:get, query) do
-            {:json, %{"valueRanges" => valueRanges}} ->
-                {:reply, {:ok, parse_value_ranges(valueRanges, options)}, state}
-            {:json, _} ->
-                {:reply, {:ok, []}, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
+    query =
+      "#{spreadsheet_id}/values:batchGet" <>
+        "?majorDimension=#{major_dimension}&valueRenderOption=#{value_render_option}" <>
+        "&dateTimeRenderOption=#{datetime_render_option}&#{str_ranges}"
+
+    case spreadsheet_query(:get, query) do
+      {:json, %{"valueRanges" => valueRanges}} ->
+        {:reply, {:ok, parse_value_ranges(valueRanges, options)}, state}
+
+      {:json, _} ->
+        {:reply, {:ok, []}, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
-    def handle_call({:read_rows, row_index_start, row_index_end, options}, from, state) do
-        column_from = Keyword.get(options, :column_from, @default_column_from)
-        column_to = Keyword.get(options, :column_to, @default_column_to)
+  end
 
-        options =
-            if Keyword.get(options, :batch_range, true) do
-                batched_range = range(row_index_start, row_index_end, column_from, column_to)
-                options
-                |> Keyword.put(:batched_ranges, [batched_range])
-                |> Keyword.put(:batched_rows, (row_index_end - row_index_start) + 1)
-            else
-                options
-            end
+  def handle_call({:read_rows, row_index_start, row_index_end, options}, from, state) do
+    column_from = Keyword.get(options, :column_from, @default_column_from)
+    column_to = Keyword.get(options, :column_to, @default_column_to)
 
-        ranges = Enum.map row_index_start..row_index_end, fn(row_index) ->
-            range(row_index, row_index, column_from, column_to)
-        end
-        handle_call({:read_rows, ranges, options}, from, state)
-    end
+    options =
+      if Keyword.get(options, :batch_range, true) do
+        batched_range = range(row_index_start, row_index_end, column_from, column_to)
 
+        options
+        |> Keyword.put(:batched_ranges, [batched_range])
+        |> Keyword.put(:batched_rows, row_index_end - row_index_start + 1)
+      else
+        options
+      end
 
-    @doc """
-    Clear rows in spreadsheet by their index.
-    """
-    def handle_call(
+    ranges =
+      Enum.map(row_index_start..row_index_end, fn row_index ->
+        range(row_index, row_index, column_from, column_to)
+      end)
+
+    handle_call({:read_rows, ranges, options}, from, state)
+  end
+
+  @doc """
+  Clear rows in spreadsheet by their index.
+  """
+  def handle_call(
         {:clear_rows, ranges, _options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        str_ranges = ranges
-        |> Enum.map(&({:ranges, "#{maybe_attach_list(state)}#{&1}"}))
-        |> URI.encode_query
-        query = "#{spreadsheet_id}/values:batchClear?#{str_ranges}"
+      ) do
+    str_ranges =
+      ranges
+      |> Enum.map(&{:ranges, "#{maybe_attach_list(state)}#{&1}"})
+      |> URI.encode_query()
 
-        case spreadsheet_query(:post, query) do
-            {:json, %{"clearedRanges" => _}} ->
-                {:reply, :ok, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
+    query = "#{spreadsheet_id}/values:batchClear?#{str_ranges}"
+
+    case spreadsheet_query(:post, query) do
+      {:json, %{"clearedRanges" => _}} ->
+        {:reply, :ok, state}
+
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
-    def handle_call({:clear_rows, row_index_start, row_index_end, options}, from, state) do
-        column_from = Keyword.get(options, :column_from, @default_column_from)
-        column_to = Keyword.get(options, :column_to, @default_column_to)
-        ranges = Enum.map row_index_start..row_index_end, fn(row_index) ->
-            range(row_index, row_index, column_from, column_to)
-        end
-        handle_call({:clear_rows, ranges, options}, from, state)
-    end
+  end
 
+  def handle_call({:clear_rows, row_index_start, row_index_end, options}, from, state) do
+    column_from = Keyword.get(options, :column_from, @default_column_from)
+    column_to = Keyword.get(options, :column_to, @default_column_to)
 
-    @doc """
-    Write values in batch based on a ranges schema.
-    """
-    def handle_call(
+    ranges =
+      Enum.map(row_index_start..row_index_end, fn row_index ->
+        range(row_index, row_index, column_from, column_to)
+      end)
+
+    handle_call({:clear_rows, ranges, options}, from, state)
+  end
+
+  @doc """
+  Write values in batch based on a ranges schema.
+  """
+  def handle_call(
         {:write_rows, ranges, data, options},
         _from,
         %{spreadsheet_id: spreadsheet_id} = state
-    ) do
-        request_data = Enum.map Enum.zip(ranges, data), fn({range, record}) ->
-            %{
-                range: "#{maybe_attach_list(state)}#{range}",
-                values: [record],
-                majorDimension: Keyword.get(options, :major_dimension, "ROWS")
-            }
-        end
-
-        request_body = %{
-            data: request_data,
-            valueInputOption: Keyword.get(options, :value_input_option, "USER_ENTERED"),
-            #includeValuesInResponse: Keyword.get(options, :include_values_in_response, false),
-            #responseValueRenderOption: Keyword.get(options, :response_value_render_option, "FORMATTED_VALUE"),
-            #responseDateTimeRenderOption: Keyword.get(options, :response_date_time_render_option, "SERIAL_NUMBER")
+      ) do
+    request_data =
+      Enum.map(Enum.zip(ranges, data), fn {range, record} ->
+        %{
+          range: "#{maybe_attach_list(state)}#{range}",
+          values: [record],
+          majorDimension: Keyword.get(options, :major_dimension, "ROWS")
         }
+      end)
 
-        query = "#{spreadsheet_id}/values:batchUpdate"
-        case spreadsheet_query_post_batch(query, request_body, options) do
-            {:json, %{"responses" => responses}} ->
-                {:reply, {:ok, responses}, state}
-            {:error, exception} ->
-                {:reply, {:error, exception}, state}
-        end
-    end
+    request_body = %{
+      data: request_data,
+      valueInputOption: Keyword.get(options, :value_input_option, "USER_ENTERED")
+      # includeValuesInResponse: Keyword.get(options, :include_values_in_response, false),
+      # responseValueRenderOption: Keyword.get(options, :response_value_render_option, "FORMATTED_VALUE"),
+      # responseDateTimeRenderOption: Keyword.get(options, :response_date_time_render_option, "SERIAL_NUMBER")
+    }
 
-    @spec spreadsheet_query(:get | :post, String.t) :: spreadsheet_response
-    defp spreadsheet_query(type, url_suffix) when is_atom(type) do
-        headers = %{"Authorization" => "Bearer #{GSS.Registry.token}"}
-        params = get_request_params()
-        response = Client.request(type, @api_url_spreadsheet <> url_suffix, "", headers, params)
-        spreadsheet_query_response(response)
-    end
-    @spec spreadsheet_query(:post | :put, String.t, spreadsheet_data, Keyword.t) :: spreadsheet_response
-    defp spreadsheet_query(type, url_suffix, data, options) when is_atom(type) do
-        headers = %{"Authorization" => "Bearer #{GSS.Registry.token}"}
-        params = get_request_params()
-        response = case type do
-            :post ->
-                body = spreadsheet_query_body(data, options)
-                Client.request(:post, @api_url_spreadsheet <> url_suffix, body, headers, params)
-            :put ->
-                body = spreadsheet_query_body(data, options)
-                Client.request(:put, @api_url_spreadsheet <> url_suffix, body, headers, params)
-        end
-        spreadsheet_query_response(response)
-    end
-    @spec spreadsheet_query_post_batch(String.t, map(), Keyword.t) :: spreadsheet_response
-    defp spreadsheet_query_post_batch(url_suffix, request, _options) do
-        headers = %{"Authorization" => "Bearer #{GSS.Registry.token}"}
-        params = get_request_params()
-        body = Poison.encode!(request)
-        response = Client.request(:post, @api_url_spreadsheet <> url_suffix, body, headers, params)
-        spreadsheet_query_response(response)
-    end
+    query = "#{spreadsheet_id}/values:batchUpdate"
 
-    @spec spreadsheet_query_response({:ok | :error, %HTTPoison.Response{}}) :: spreadsheet_response
-    defp spreadsheet_query_response(response) do
-        with \
-            {:ok, %{status_code: 200, body: body}} <- response,
-            {:ok, json} <- Poison.decode(body) do
-            {:json, json}
-        else
-            {:ok, %{status_code: status_code, body: body}} when status_code != 200 ->
-                Logger.error "Google API returned status code: #{status_code}. Body: #{body}"
-                {:error, %GSS.GoogleApiError{message: "invalid google API status code #{status_code}"}}
-            {:error, reason}->
-                Logger.error fn -> "Spreadsheet query: #{inspect(reason)}" end
-                {:error, %GSS.GoogleApiError{message: "invalid google API response #{inspect(reason)}"}}
-        end
-    end
+    case spreadsheet_query_post_batch(query, request_body, options) do
+      {:json, %{"responses" => responses}} ->
+        {:reply, {:ok, responses}, state}
 
-    @spec spreadsheet_query_body(spreadsheet_data, Keyword.t) :: String.t | no_return()
-    defp spreadsheet_query_body(data, options) do
-        range = Keyword.fetch!(options, :range)
-        major_dimension = Keyword.get(options, :major_dimension, "ROWS")
-        Poison.encode! %{
-            range: range,
-            majorDimension: major_dimension,
-            values: [data]
-        }
+      {:error, exception} ->
+        {:reply, {:error, exception}, state}
     end
+  end
 
-    @spec range(integer(), integer(), integer(), integer()) :: String.t
-    def range(row_from, row_to, column_from, column_to)
-    when row_from <= row_to and column_from <= column_to and row_to - row_from < @max_rows do
-        column_from_letters = col_number_to_letters(column_from)
-        column_to_letters = col_number_to_letters(column_to)
-        "#{column_from_letters}#{row_from}:#{column_to_letters}#{row_to}"
-    end
-    def range(_, _, _, _) do
-        raise GSS.InvalidRange,
-            message: "Max rows #{@max_rows}, `to` value should be greater than `from`"
-    end
-    @spec range(integer(), integer(), integer(), integer(), state) :: String.t
-    def range(row_from, row_to, column_from, column_to, state) do
-        maybe_attach_list(state) <> range(row_from, row_to, column_from, column_to)
-    end
+  @spec spreadsheet_query(:get | :post, String.t()) :: spreadsheet_response
+  defp spreadsheet_query(type, url_suffix) when is_atom(type) do
+    headers = %{"Authorization" => "Bearer #{GSS.Registry.token()}"}
+    params = get_request_params()
+    response = Client.request(type, @api_url_spreadsheet <> url_suffix, "", headers, params)
+    spreadsheet_query_response(response)
+  end
 
-    @spec pad(integer()) :: spreadsheet_data
-    defp pad(amount) do
-        for _i <- 1..amount, do: ""
-    end
+  @spec spreadsheet_query(:post | :put, String.t(), spreadsheet_data, Keyword.t()) ::
+          spreadsheet_response
+  defp spreadsheet_query(type, url_suffix, data, options) when is_atom(type) do
+    headers = %{"Authorization" => "Bearer #{GSS.Registry.token()}"}
+    params = get_request_params()
 
-    @spec col_number_to_letters(integer()) :: String.t
-    def col_number_to_letters(col_number) do
-      indices = index_to_index_list(col_number - 1)
-      charlist = for i <- indices, do: i + ?A
-      to_string(charlist)
-    end
+    response =
+      case type do
+        :post ->
+          body = spreadsheet_query_body(data, options)
+          Client.request(:post, @api_url_spreadsheet <> url_suffix, body, headers, params)
 
-    defp index_to_index_list(index, list \\ [])
-    defp index_to_index_list(index, list) when index >= 26 do
-      index_to_index_list(div(index, 26) - 1, [rem(index, 26) | list])
-    end
-    defp index_to_index_list(index, list) when index >= 0 and index < 26 do
-      [index | list]
-    end
+        :put ->
+          body = spreadsheet_query_body(data, options)
+          Client.request(:put, @api_url_spreadsheet <> url_suffix, body, headers, params)
+      end
 
-    @spec maybe_attach_list(state) :: String.t
-    defp maybe_attach_list(%{list_name: nil}), do: ""
-    defp maybe_attach_list(%{list_name: list_name}) when is_bitstring(list_name), do: "#{list_name}!"
+    spreadsheet_query_response(response)
+  end
 
+  @spec spreadsheet_query_post_batch(String.t(), map(), Keyword.t()) :: spreadsheet_response
+  defp spreadsheet_query_post_batch(url_suffix, request, _options) do
+    headers = %{"Authorization" => "Bearer #{GSS.Registry.token()}"}
+    params = get_request_params()
+    body = Poison.encode!(request)
+    response = Client.request(:post, @api_url_spreadsheet <> url_suffix, body, headers, params)
+    spreadsheet_query_response(response)
+  end
 
-    @spec parse_value_ranges([map()], Keyword.t) :: [[String.t] | nil]
-    defp parse_value_ranges(value_ranges, options) do
-        column_to = Keyword.get(options, :column_to)
-        parse_value_ranges(value_ranges, options, column_to)
+  @spec spreadsheet_query_response({:ok | :error, %HTTPoison.Response{}}) :: spreadsheet_response
+  defp spreadsheet_query_response(response) do
+    with {:ok, %{status_code: 200, body: body}} <- response,
+         {:ok, json} <- Poison.decode(body) do
+      {:json, json}
+    else
+      {:ok, %{status_code: status_code, body: body}} when status_code != 200 ->
+        Logger.error("Google API returned status code: #{status_code}. Body: #{body}")
+        {:error, %GSS.GoogleApiError{message: "invalid google API status code #{status_code}"}}
+
+      {:error, reason} ->
+        Logger.error(fn -> "Spreadsheet query: #{inspect(reason)}" end)
+        {:error, %GSS.GoogleApiError{message: "invalid google API response #{inspect(reason)}"}}
     end
-    @spec parse_value_ranges([map()], Keyword.t, integer() | nil) :: [[String.t] | nil]
-    defp parse_value_ranges(value_ranges, options, column_to) when is_integer(column_to) or is_nil(column_to) do
-        total_rows = Keyword.get(options, :batched_rows, 1)
-        pad_empty = Keyword.get(options, :pad_empty, false)
-        response = Enum.flat_map value_ranges, &(parse_value(&1, column_to, pad_empty))
-        if length(response) < total_rows do
-            padding = List.duplicate(empty_row(column_to, pad_empty), total_rows - length(response))
-            response ++ padding
-        else
-            response
-        end
-    end
+  end
 
-    @spec parse_value(map(), integer() | nil, boolean()) :: [[String.t] | nil]
-    defp parse_value(%{"values" => values}, column_to, _) when is_list(values) and is_integer(column_to) do
-        Enum.map values, &(value_range_block_wrapper(&1, column_to))
-    end
-    defp parse_value(%{"values" => values}, _, false) when is_list(values), do: values
-    defp parse_value(_, column_to, pad_empty), do: [empty_row(column_to, pad_empty)]
+  @spec spreadsheet_query_body(spreadsheet_data, Keyword.t()) :: String.t() | no_return()
+  defp spreadsheet_query_body(data, options) do
+    range = Keyword.fetch!(options, :range)
+    major_dimension = Keyword.get(options, :major_dimension, "ROWS")
 
-    @spec empty_row(integer() | nil, boolean()) :: [String.t] | nil
-    defp empty_row(nil, true), do: []
-    defp empty_row(column_to, true), do: pad(column_to)
-    defp empty_row(_, false), do: nil
+    Poison.encode!(%{
+      range: range,
+      majorDimension: major_dimension,
+      values: [data]
+    })
+  end
 
-    @spec value_range_block_wrapper([String.t], integer()) :: [String.t]
-    defp value_range_block_wrapper(values, column_to) when length(values) >= column_to, do: values
-    defp value_range_block_wrapper(values, column_to) do
-        pad_amount = column_to - length(values)
-        values ++ pad(pad_amount)
-    end
+  @spec range(integer(), integer(), integer(), integer()) :: String.t()
+  def range(row_from, row_to, column_from, column_to)
+      when row_from <= row_to and column_from <= column_to and row_to - row_from < @max_rows do
+    column_from_letters = col_number_to_letters(column_from)
+    column_to_letters = col_number_to_letters(column_to)
+    "#{column_from_letters}#{row_from}:#{column_to_letters}#{row_to}"
+  end
 
-    @spec get_request_params() :: Keyword.t
-    defp get_request_params do
-        @default_request_params
-        |> Keyword.merge(Client.config(:request_opts, []))
+  def range(_, _, _, _) do
+    raise GSS.InvalidRange,
+      message: "Max rows #{@max_rows}, `to` value should be greater than `from`"
+  end
+
+  @spec range(integer(), integer(), integer(), integer(), state) :: String.t()
+  def range(row_from, row_to, column_from, column_to, state) do
+    maybe_attach_list(state) <> range(row_from, row_to, column_from, column_to)
+  end
+
+  @spec pad(integer()) :: spreadsheet_data
+  defp pad(amount) do
+    for _i <- 1..amount, do: ""
+  end
+
+  @spec col_number_to_letters(integer()) :: String.t()
+  def col_number_to_letters(col_number) do
+    indices = index_to_index_list(col_number - 1)
+    charlist = for i <- indices, do: i + ?A
+    to_string(charlist)
+  end
+
+  defp index_to_index_list(index, list \\ [])
+
+  defp index_to_index_list(index, list) when index >= 26 do
+    index_to_index_list(div(index, 26) - 1, [rem(index, 26) | list])
+  end
+
+  defp index_to_index_list(index, list) when index >= 0 and index < 26 do
+    [index | list]
+  end
+
+  @spec maybe_attach_list(state) :: String.t()
+  defp maybe_attach_list(%{list_name: nil}), do: ""
+
+  defp maybe_attach_list(%{list_name: list_name}) when is_bitstring(list_name),
+    do: "#{list_name}!"
+
+  @spec parse_value_ranges([map()], Keyword.t()) :: [[String.t()] | nil]
+  defp parse_value_ranges(value_ranges, options) do
+    column_to = Keyword.get(options, :column_to)
+    parse_value_ranges(value_ranges, options, column_to)
+  end
+
+  @spec parse_value_ranges([map()], Keyword.t(), integer() | nil) :: [[String.t()] | nil]
+  defp parse_value_ranges(value_ranges, options, column_to)
+       when is_integer(column_to) or is_nil(column_to) do
+    total_rows = Keyword.get(options, :batched_rows, 1)
+    pad_empty = Keyword.get(options, :pad_empty, false)
+    response = Enum.flat_map(value_ranges, &parse_value(&1, column_to, pad_empty))
+
+    if length(response) < total_rows do
+      padding = List.duplicate(empty_row(column_to, pad_empty), total_rows - length(response))
+      response ++ padding
+    else
+      response
     end
+  end
+
+  @spec parse_value(map(), integer() | nil, boolean()) :: [[String.t()] | nil]
+  defp parse_value(%{"values" => values}, column_to, _)
+       when is_list(values) and is_integer(column_to) do
+    Enum.map(values, &value_range_block_wrapper(&1, column_to))
+  end
+
+  defp parse_value(%{"values" => values}, _, false) when is_list(values), do: values
+  defp parse_value(_, column_to, pad_empty), do: [empty_row(column_to, pad_empty)]
+
+  @spec empty_row(integer() | nil, boolean()) :: [String.t()] | nil
+  defp empty_row(nil, true), do: []
+  defp empty_row(column_to, true), do: pad(column_to)
+  defp empty_row(_, false), do: nil
+
+  @spec value_range_block_wrapper([String.t()], integer()) :: [String.t()]
+  defp value_range_block_wrapper(values, column_to) when length(values) >= column_to, do: values
+
+  defp value_range_block_wrapper(values, column_to) do
+    pad_amount = column_to - length(values)
+    values ++ pad(pad_amount)
+  end
+
+  @spec get_request_params() :: Keyword.t()
+  defp get_request_params do
+    @default_request_params
+    |> Keyword.merge(Client.config(:request_opts, []))
+  end
 
   defp gen_server_call(pid, tuple, options) do
     case Keyword.get(options, :timeout) do
       nil ->
         GenServer.call(pid, tuple)
+
       timeout ->
         GenServer.call(pid, tuple, timeout)
     end

--- a/lib/elixir_google_spreadsheets/spreadsheet/supervisor.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet/supervisor.ex
@@ -1,28 +1,28 @@
 defmodule GSS.Spreadsheet.Supervisor do
-    @moduledoc """
-    Supervisor to keep track of initialized spreadsheet processes.
-    """
+  @moduledoc """
+  Supervisor to keep track of initialized spreadsheet processes.
+  """
 
-    use Supervisor
+  use Supervisor
 
-    @spec start_link() :: {:ok, pid}
-    def start_link do
-        Supervisor.start_link(__MODULE__, [], name: __MODULE__)
-    end
+  @spec start_link() :: {:ok, pid}
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
 
-    @spec spreadsheet(String.t, Keyword.t) :: {:ok, pid}
-    def spreadsheet(spreadsheet_id, opts \\ []) do
-        {:ok, pid} = Supervisor.start_child(__MODULE__, [spreadsheet_id, opts])
-        :ok = GSS.Registry.new_spreadsheet(spreadsheet_id, pid, opts)
-        {:ok, pid}
-    end
+  @spec spreadsheet(String.t(), Keyword.t()) :: {:ok, pid}
+  def spreadsheet(spreadsheet_id, opts \\ []) do
+    {:ok, pid} = Supervisor.start_child(__MODULE__, [spreadsheet_id, opts])
+    :ok = GSS.Registry.new_spreadsheet(spreadsheet_id, pid, opts)
+    {:ok, pid}
+  end
 
-    @spec init([]) :: {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}} | :ignore
-    def init([]) do
-        children = [
-            worker(GSS.Spreadsheet, [], restart: :transient)
-        ]
+  @spec init([]) :: {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}} | :ignore
+  def init([]) do
+    children = [
+      worker(GSS.Spreadsheet, [], restart: :transient)
+    ]
 
-        supervise(children, strategy: :simple_one_for_one)
-    end
+    supervise(children, strategy: :simple_one_for_one)
+  end
 end

--- a/lib/elixir_google_spreadsheets/supervisor.ex
+++ b/lib/elixir_google_spreadsheets/supervisor.ex
@@ -1,23 +1,23 @@
 defmodule GSS.Supervisor do
-    @moduledoc """
-    Supervisor tree to keep track of registry and spreadsheet supervisor.
-    """
+  @moduledoc """
+  Supervisor tree to keep track of registry and spreadsheet supervisor.
+  """
 
-    use Supervisor
+  use Supervisor
 
-    @spec start_link() :: {:ok, pid()}
-    def start_link do
-        Supervisor.start_link(__MODULE__, [])
-    end
+  @spec start_link() :: {:ok, pid()}
+  def start_link do
+    Supervisor.start_link(__MODULE__, [])
+  end
 
-    @spec init([]) :: {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}} | :ignore
-    def init([]) do
-        children = [
-            worker(GSS.Registry, []),
-            supervisor(GSS.Spreadsheet.Supervisor, []),
-            supervisor(GSS.Client.Supervisor, [])
-        ]
+  @spec init([]) :: {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}} | :ignore
+  def init([]) do
+    children = [
+      worker(GSS.Registry, []),
+      supervisor(GSS.Spreadsheet.Supervisor, []),
+      supervisor(GSS.Client.Supervisor, [])
+    ]
 
-        supervise(children, strategy: :one_for_all)
-    end
+    supervise(children, strategy: :one_for_all)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,57 +1,57 @@
 defmodule GSS.Mixfile do
-    use Mix.Project
+  use Mix.Project
 
-    def project do
-        [
-            app: :elixir_google_spreadsheets,
-            version: "0.1.10",
-            elixir: "~> 1.4",
-            description: "Elixir library to read and write data of Google Spreadsheets.",
-            docs: [extras: ["README.md"]],
-            build_embedded: Mix.env == :prod,
-            start_permanent: Mix.env == :prod,
-            package: package(),
-            elixirc_paths: elixirc_paths(Mix.env),
-            deps: deps()
-        ]
-    end
+  def project do
+    [
+      app: :elixir_google_spreadsheets,
+      version: "0.1.10",
+      elixir: "~> 1.4",
+      description: "Elixir library to read and write data of Google Spreadsheets.",
+      docs: [extras: ["README.md"]],
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      package: package(),
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
+    ]
+  end
 
-    def package do
-        [
-            name: :elixir_google_spreadsheets,
-            files: ["lib", "mix.exs"],
-            maintainers: ["Vyacheslav Voronchuk"],
-            licenses: ["MIT"],
-            links: %{"Github" => "https://github.com/Voronchuk/elixir_google_spreadsheets"},
-        ]
-    end
+  def package do
+    [
+      name: :elixir_google_spreadsheets,
+      files: ["lib", "mix.exs"],
+      maintainers: ["Vyacheslav Voronchuk"],
+      licenses: ["MIT"],
+      links: %{"Github" => "https://github.com/Voronchuk/elixir_google_spreadsheets"}
+    ]
+  end
 
-    def application do
-        [
-            applications: [
-                :logger,
-                :goth,
-                :httpoison,
-                :gen_stage,
-                :poison
-            ],
-            mod: {GSS, []}
-        ]
-    end
+  def application do
+    [
+      applications: [
+        :logger,
+        :goth,
+        :httpoison,
+        :gen_stage,
+        :poison
+      ],
+      mod: {GSS, []}
+    ]
+  end
 
-    defp deps do
-        [
-            {:goth, ">= 0.5.0"},
-            {:httpoison, ">= 0.12.0"},
-            {:gen_stage, ">= 0.12.0"},
-            {:poison, "~> 3.1"},
-            {:earmark, ">= 0.0.0", only: :dev},
-            {:ex_doc, ">= 0.0.0", only: :dev},
-            {:logger_file_backend, ">= 0.0.10", only: [:dev, :test]},
-            {:dialyxir, "~> 0.5", only: :dev, runtime: false}
-        ]
-    end
+  defp deps do
+    [
+      {:goth, ">= 0.5.0"},
+      {:httpoison, ">= 0.12.0"},
+      {:gen_stage, ">= 0.12.0"},
+      {:poison, "~> 3.1"},
+      {:earmark, ">= 0.0.0", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:logger_file_backend, ">= 0.0.10", only: [:dev, :test]},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false}
+    ]
+  end
 
-    defp elixirc_paths(:test), do: ["lib", "test/stub_modules"]
-    defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(:test), do: ["lib", "test/stub_modules"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/elixir_google_spreadsheets/authorization_test.exs
+++ b/test/elixir_google_spreadsheets/authorization_test.exs
@@ -1,7 +1,7 @@
 defmodule GSS.AuthorizationTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    test "fetch account access token to work with Google Spreadsheets" do
-        assert GSS.Registry.token
-    end
+  test "fetch account access token to work with Google Spreadsheets" do
+    assert GSS.Registry.token()
+  end
 end

--- a/test/elixir_google_spreadsheets/client/limiter_test.exs
+++ b/test/elixir_google_spreadsheets/client/limiter_test.exs
@@ -1,62 +1,67 @@
 defmodule GSS.Client.LimiterTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    alias GSS.Client.Limiter
-    alias GSS.StubModules.{Producer, Consumer}
+  alias GSS.Client.Limiter
+  alias GSS.StubModules.{Producer, Consumer}
 
-    setup context do
-        {:ok, client} = Producer.start_link([])
-        {:ok, limiter} = GenStage.start_link(
-            Limiter,
-            name: context.test,
-            clients: [client],
-            max_demand: 3, max_interval: 500, interval: 0
-        )
-        {:ok, _consumer} = Consumer.start_link(limiter)
+  setup context do
+    {:ok, client} = Producer.start_link([])
 
-        [client: client, limiter: limiter]
-    end
+    {:ok, limiter} =
+      GenStage.start_link(
+        Limiter,
+        name: context.test,
+        clients: [client],
+        max_demand: 3,
+        max_interval: 500,
+        interval: 0
+      )
 
-    test "receive events in packs with limits", %{client: client} do
-        GenStage.call(client, {:add, [1, 2, 3, 4, 5]})
+    {:ok, _consumer} = Consumer.start_link(limiter)
 
-        assert_receive {:handled_demand, [1, 2, 3], 3}
-        refute_receive {:handled_demand, [4, 5], 3}, 400, "error waiting limits"
-        assert_receive {:handled_demand, [4, 5], 3}, 200
-        assert_receive {:handled_demand, [], 3}
+    [client: client, limiter: limiter]
+  end
 
-        GenStage.call(client, {:add, [6, 7, 8, 9]})
+  test "receive events in packs with limits", %{client: client} do
+    GenStage.call(client, {:add, [1, 2, 3, 4, 5]})
 
-        assert_receive {:handled_demand, [6, 7, 8], 3}
-        refute_receive {:handled_demand, [9], 3}, 400, "error waiting limits"
+    assert_receive {:handled_demand, [1, 2, 3], 3}
+    refute_receive {:handled_demand, [4, 5], 3}, 400, "error waiting limits"
+    assert_receive {:handled_demand, [4, 5], 3}, 200
+    assert_receive {:handled_demand, [], 3}
 
-        assert_receive {:handled_demand, [9], 3}, 200
-        assert_receive {:handled_demand, [], 3}
-    end
+    GenStage.call(client, {:add, [6, 7, 8, 9]})
+
+    assert_receive {:handled_demand, [6, 7, 8], 3}
+    refute_receive {:handled_demand, [9], 3}, 400, "error waiting limits"
+
+    assert_receive {:handled_demand, [9], 3}, 200
+    assert_receive {:handled_demand, [], 3}
+  end
 
   test "receive events with limits", %{client: client} do
-        GenStage.call(client, {:add, [1]})
-        assert_receive {:handled_demand, [1], 3}
+    GenStage.call(client, {:add, [1]})
+    assert_receive {:handled_demand, [1], 3}
 
-        GenStage.call(client, {:add, [2]})
-        assert_receive {:handled_demand, [2], 3}
+    GenStage.call(client, {:add, [2]})
+    assert_receive {:handled_demand, [2], 3}
 
-        GenStage.call(client, {:add, [3]})
-        assert_receive {:handled_demand, [3], 3}
+    GenStage.call(client, {:add, [3]})
+    assert_receive {:handled_demand, [3], 3}
 
-        GenStage.call(client, {:add, [4]})
-        GenStage.call(client, {:add, [5]})
+    GenStage.call(client, {:add, [4]})
+    GenStage.call(client, {:add, [5]})
 
-        refute_receive {:handled_demand, [4, 5], 3}, 400, "error waiting limits"
-        assert_receive {:handled_demand, [4, 5], 3}, 200
+    refute_receive {:handled_demand, [4, 5], 3}, 400, "error waiting limits"
+    assert_receive {:handled_demand, [4, 5], 3}, 200
   end
 
   test "receive events in expired interval", %{client: client} do
-        GenStage.call(client, {:add, [1]})
-        assert_receive {:handled_demand, [1], 3}
-        Process.sleep(500)
+    GenStage.call(client, {:add, [1]})
+    assert_receive {:handled_demand, [1], 3}
+    Process.sleep(500)
 
-        GenStage.call(client, {:add, [2]})
-        assert_receive {:handled_demand, [2], 3}
+    GenStage.call(client, {:add, [2]})
+    assert_receive {:handled_demand, [2], 3}
   end
 end

--- a/test/elixir_google_spreadsheets/client_test.exs
+++ b/test/elixir_google_spreadsheets/client_test.exs
@@ -1,83 +1,83 @@
 defmodule GSS.ClientTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    alias GSS.{Client.RequestParams, Client}
-    alias GSS.StubModules.Consumer
+  alias GSS.{Client.RequestParams, Client}
+  alias GSS.StubModules.Consumer
 
-    describe ".request" do
-        setup do
-            {:ok, client} = GenStage.start_link(GSS.Client, :ok)
+  describe ".request" do
+    setup do
+      {:ok, client} = GenStage.start_link(GSS.Client, :ok)
 
-            client
-            |> send_request(:get, 1)
-            |> send_request(:post, 2)
-            |> send_request(:get, 3)
-            |> send_request(:put, 4)
-            |> send_request(:get, 5)
+      client
+      |> send_request(:get, 1)
+      |> send_request(:post, 2)
+      |> send_request(:get, 3)
+      |> send_request(:put, 4)
+      |> send_request(:get, 5)
 
-            [client: client]
-        end
-
-        def send_request(client, method, num) do
-            request = create_request(method, num)
-            Task.async(fn -> GenStage.call(client, {:request, request}, 50_000) end)
-            client
-        end
-
-        def create_request(method, num) do
-            %RequestParams{method: method, url: "http://url/?n=#{num}"}
-        end
-
-        test "add request events to the queue and release them to read consumer", %{client: client} do
-            {:ok, _cons} = Consumer.start_link({client, partition: :read})
-
-            assert_receive {:received, [event1, event2, event3]}
-            request1 = create_request(:get, 1)
-            assert {:request, _, ^request1} = event1
-
-            request2 = create_request(:get, 3)
-            assert {:request, _, ^request2} = event2
-
-            request3 = create_request(:get, 5)
-            assert {:request, _, ^request3} = event3
-        end
-
-        test "add request events to the queue and release them to write consumer", %{client: client} do
-            {:ok, _cons} = Consumer.start_link({client, partition: :write})
-
-            assert_receive {:received, [event1, event2]}
-            request1 = create_request(:post, 2)
-            assert {:request, _, ^request1} = event1
-
-            request2 = create_request(:put, 4)
-            assert {:request, _, ^request2} = event2
-        end
+      [client: client]
     end
 
-    describe ".dispatcher_hash/1" do
-        setup do
-            request = %RequestParams{url: "http://localhost"}
-            %{request: request}
-        end
-
-        test "get request to :read partition", %{request: request} do
-            event = {:request, self(), %{request | method: :get}}
-            assert {event, :read} == Client.dispatcher_hash(event)
-        end
-
-        test "post request to :write partition", %{request: request} do
-            event = {:request, self(), %{request | method: :post}}
-            assert {event, :write} == Client.dispatcher_hash(event)
-        end
-
-        test "put request to :write partition", %{request: request} do
-            event = {:request, self(), %{request | method: :put}}
-            assert {event, :write} == Client.dispatcher_hash(event)
-        end
-
-        test "patch request to :write partition", %{request: request} do
-            event = {:request, self(), %{request | method: :patch}}
-            assert {event, :write} == Client.dispatcher_hash(event)
-        end
+    def send_request(client, method, num) do
+      request = create_request(method, num)
+      Task.async(fn -> GenStage.call(client, {:request, request}, 50_000) end)
+      client
     end
+
+    def create_request(method, num) do
+      %RequestParams{method: method, url: "http://url/?n=#{num}"}
+    end
+
+    test "add request events to the queue and release them to read consumer", %{client: client} do
+      {:ok, _cons} = Consumer.start_link({client, partition: :read})
+
+      assert_receive {:received, [event1, event2, event3]}
+      request1 = create_request(:get, 1)
+      assert {:request, _, ^request1} = event1
+
+      request2 = create_request(:get, 3)
+      assert {:request, _, ^request2} = event2
+
+      request3 = create_request(:get, 5)
+      assert {:request, _, ^request3} = event3
+    end
+
+    test "add request events to the queue and release them to write consumer", %{client: client} do
+      {:ok, _cons} = Consumer.start_link({client, partition: :write})
+
+      assert_receive {:received, [event1, event2]}
+      request1 = create_request(:post, 2)
+      assert {:request, _, ^request1} = event1
+
+      request2 = create_request(:put, 4)
+      assert {:request, _, ^request2} = event2
+    end
+  end
+
+  describe ".dispatcher_hash/1" do
+    setup do
+      request = %RequestParams{url: "http://localhost"}
+      %{request: request}
+    end
+
+    test "get request to :read partition", %{request: request} do
+      event = {:request, self(), %{request | method: :get}}
+      assert {event, :read} == Client.dispatcher_hash(event)
+    end
+
+    test "post request to :write partition", %{request: request} do
+      event = {:request, self(), %{request | method: :post}}
+      assert {event, :write} == Client.dispatcher_hash(event)
+    end
+
+    test "put request to :write partition", %{request: request} do
+      event = {:request, self(), %{request | method: :put}}
+      assert {event, :write} == Client.dispatcher_hash(event)
+    end
+
+    test "patch request to :write partition", %{request: request} do
+      event = {:request, self(), %{request | method: :patch}}
+      assert {event, :write} == Client.dispatcher_hash(event)
+    end
+  end
 end

--- a/test/elixir_google_spreadsheets/spreadsheet_list_test.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_list_test.exs
@@ -1,97 +1,110 @@
 defmodule GSS.SpreadsheetListTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    @test_spreadsheet_id Application.fetch_env!(:elixir_google_spreadsheets, :spreadsheet_id)
-    @test_list "list space"
-    @test_row1 ["1", "2", "3", "4", "5"]
-    @test_row2 ["6", "1", "2", "3", "4", "0"]
-    @test_row3 ["7", "7", "8"]
+  @test_spreadsheet_id Application.fetch_env!(:elixir_google_spreadsheets, :spreadsheet_id)
+  @test_list "list space"
+  @test_row1 ["1", "2", "3", "4", "5"]
+  @test_row2 ["6", "1", "2", "3", "4", "0"]
+  @test_row3 ["7", "7", "8"]
 
-    setup context do
-        {:ok, pid} = GSS.Spreadsheet.Supervisor.spreadsheet(@test_spreadsheet_id, name: context.test, list_name: @test_list)
-        on_exit fn ->
-            cleanup_table(pid)
-            :ok = Supervisor.terminate_child(GSS.Spreadsheet.Supervisor, pid)
-        end
-        {:ok, spreadsheet: pid}
-    end
+  setup context do
+    {:ok, pid} =
+      GSS.Spreadsheet.Supervisor.spreadsheet(
+        @test_spreadsheet_id,
+        name: context.test,
+        list_name: @test_list
+      )
 
-    @spec cleanup_table(pid) :: :ok
-    defp cleanup_table(pid) do
-        GSS.Spreadsheet.clear_row(pid, 1)
-        GSS.Spreadsheet.clear_row(pid, 2)
-        GSS.Spreadsheet.clear_row(pid, 3)
-        GSS.Spreadsheet.clear_row(pid, 4)
-    end
+    on_exit(fn ->
+      cleanup_table(pid)
+      :ok = Supervisor.terminate_child(GSS.Spreadsheet.Supervisor, pid)
+    end)
 
-    test "initialize new spreadsheet list process", %{spreadsheet: pid} do
-        assert GSS.Registry.spreadsheet_pid(@test_spreadsheet_id, list_name: @test_list) == pid
-        assert GSS.Spreadsheet.id(pid) == @test_spreadsheet_id
-        sheets = GSS.Spreadsheet.sheets(pid)
-        assert Map.get(sheets, @test_list)
-    end
+    {:ok, spreadsheet: pid}
+  end
 
-    test "read total number of filled rows in list", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.rows(pid)
-        assert result == 0
-    end
+  @spec cleanup_table(pid) :: :ok
+  defp cleanup_table(pid) do
+    GSS.Spreadsheet.clear_row(pid, 1)
+    GSS.Spreadsheet.clear_row(pid, 2)
+    GSS.Spreadsheet.clear_row(pid, 3)
+    GSS.Spreadsheet.clear_row(pid, 4)
+  end
 
-    test "read 5 columns from the 1 row in a spreadsheet list", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
-        assert result == ["", "", "", "", ""]
-    end
+  test "initialize new spreadsheet list process", %{spreadsheet: pid} do
+    assert GSS.Registry.spreadsheet_pid(@test_spreadsheet_id, list_name: @test_list) == pid
+    assert GSS.Spreadsheet.id(pid) == @test_spreadsheet_id
+    sheets = GSS.Spreadsheet.sheets(pid)
+    assert Map.get(sheets, @test_list)
+  end
 
-    test "write new row lines in the end of document list", %{spreadsheet: pid} do
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
-        assert result == @test_row1
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
-        assert result == @test_row2
-    end
+  test "read total number of filled rows in list", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.rows(pid)
+    assert result == 0
+  end
 
-    test "write some lines and append row between them on list", %{spreadsheet: pid} do
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
-        :ok = GSS.Spreadsheet.append_row(pid, 1, @test_row3)
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 3, column_to: 3)
-        assert result == @test_row3
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
-        assert result == @test_row2
-    end
+  test "read 5 columns from the 1 row in a spreadsheet list", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
+    assert result == ["", "", "", "", ""]
+  end
 
-    test "read batched for 2 rows in list", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5)
-        assert result == [nil, nil]
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, pad_empty: true)
-        assert result == [["", "", "", "", ""], ["", "", "", "", ""]]
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, pad_empty: true)
-        assert result == [@test_row1, ["", "", "", "", ""]]
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, ["A1:E1", "A2:E2"])
-        assert result == [@test_row1, nil]
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, [1, 2], column_to: 5)
-        assert result == [@test_row1, nil]
-    end
+  test "write new row lines in the end of document list", %{spreadsheet: pid} do
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
+    assert result == @test_row1
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
+    assert result == @test_row2
+  end
 
-    test "clear batched for 2 rows in list", %{spreadsheet: pid} do
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row1)
-        :ok = GSS.Spreadsheet.clear_rows(pid, ["A1:E1", "A2:E2"])
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5)
-        assert result == [nil, nil]
-    end
+  test "write some lines and append row between them on list", %{spreadsheet: pid} do
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
+    :ok = GSS.Spreadsheet.append_row(pid, 1, @test_row3)
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 3, column_to: 3)
+    assert result == @test_row3
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
+    assert result == @test_row2
+  end
 
-    test "write batched for 2 rows in list", %{spreadsheet: pid} do
-        {:ok, _} = GSS.Spreadsheet.write_rows(pid, ["A2:E2", "A3:F3"], [@test_row1, @test_row2])
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
-        assert result == [@test_row1 ++ [""], @test_row2]
-    end
+  test "read batched for 2 rows in list", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5)
+    assert result == [nil, nil]
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, pad_empty: true)
+    assert result == [["", "", "", "", ""], ["", "", "", "", ""]]
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, pad_empty: true)
+    assert result == [@test_row1, ["", "", "", "", ""]]
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, ["A1:E1", "A2:E2"])
+    assert result == [@test_row1, nil]
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, [1, 2], column_to: 5)
+    assert result == [@test_row1, nil]
+  end
 
-    test "unexisting lists should gracefully fail", %{spreadsheet: pid} do
-        {:ok, pid} = GSS.Spreadsheet.Supervisor.spreadsheet(@test_spreadsheet_id, name: :unknown_list, list_name: "unknown")
-        sheets = GSS.Spreadsheet.sheets(pid)
-        refute Map.get(sheets, "unknown")
-        assert {:error, _} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
-    end
+  test "clear batched for 2 rows in list", %{spreadsheet: pid} do
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row1)
+    :ok = GSS.Spreadsheet.clear_rows(pid, ["A1:E1", "A2:E2"])
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5)
+    assert result == [nil, nil]
+  end
+
+  test "write batched for 2 rows in list", %{spreadsheet: pid} do
+    {:ok, _} = GSS.Spreadsheet.write_rows(pid, ["A2:E2", "A3:F3"], [@test_row1, @test_row2])
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
+    assert result == [@test_row1 ++ [""], @test_row2]
+  end
+
+  test "unexisting lists should gracefully fail", %{spreadsheet: pid} do
+    {:ok, pid} =
+      GSS.Spreadsheet.Supervisor.spreadsheet(
+        @test_spreadsheet_id,
+        name: :unknown_list,
+        list_name: "unknown"
+      )
+
+    sheets = GSS.Spreadsheet.sheets(pid)
+    refute Map.get(sheets, "unknown")
+    assert {:error, _} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
+  end
 end

--- a/test/elixir_google_spreadsheets/spreadsheet_range.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_range.exs
@@ -1,45 +1,45 @@
 defmodule GSS.SpreadsheetRangeTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    describe "range/4 with one row" do
-        test "generates range for length 14" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 14) == "A1:N1"
-        end
-
-        test "generates range for length 26" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 26) == "A1:Z1"
-        end
-
-        test "generates range for length 27" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 27) == "A1:AA1"
-        end
-
-        test "generates range for length 52" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 52) == "A1:AZ1"
-        end
-
-        test "generates range for length 53" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 53) == "A1:BA1"
-        end
-
-        test "genearates range for length 254" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 254) == "A1:IT1"
-        end
-
-        test "generates range for length 255" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 255) == "A1:IU1"
-        end
-
-        test "generates range for length 702" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 702) == "A1:ZZ1"
-        end
-
-        test "generates range for length 703" do
-            assert GSS.Spreadsheet.range(1, 1, 1, 703) == "A1:AAA1"
-        end
-
-        test "generates range for multiple rows" do
-            assert GSS.Spreadsheet.range(1, 10, 1, 10) == "A1:J10"
-        end
+  describe "range/4 with one row" do
+    test "generates range for length 14" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 14) == "A1:N1"
     end
+
+    test "generates range for length 26" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 26) == "A1:Z1"
+    end
+
+    test "generates range for length 27" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 27) == "A1:AA1"
+    end
+
+    test "generates range for length 52" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 52) == "A1:AZ1"
+    end
+
+    test "generates range for length 53" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 53) == "A1:BA1"
+    end
+
+    test "genearates range for length 254" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 254) == "A1:IT1"
+    end
+
+    test "generates range for length 255" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 255) == "A1:IU1"
+    end
+
+    test "generates range for length 702" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 702) == "A1:ZZ1"
+    end
+
+    test "generates range for length 703" do
+      assert GSS.Spreadsheet.range(1, 1, 1, 703) == "A1:AAA1"
+    end
+
+    test "generates range for multiple rows" do
+      assert GSS.Spreadsheet.range(1, 10, 1, 10) == "A1:J10"
+    end
+  end
 end

--- a/test/elixir_google_spreadsheets/spreadsheet_test.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_test.exs
@@ -1,106 +1,107 @@
 defmodule GSS.SpreadsheetTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    @test_spreadsheet_id Application.fetch_env!(:elixir_google_spreadsheets, :spreadsheet_id)
-    @test_row1 ["1", "2", "3", "4", "5"]
-    @test_row2 ["6", "1", "2", "3", "4", "0"]
-    @test_row3 ["7", "7", "8"]
+  @test_spreadsheet_id Application.fetch_env!(:elixir_google_spreadsheets, :spreadsheet_id)
+  @test_row1 ["1", "2", "3", "4", "5"]
+  @test_row2 ["6", "1", "2", "3", "4", "0"]
+  @test_row3 ["7", "7", "8"]
 
-    setup context do
-        {:ok, pid} = GSS.Spreadsheet.Supervisor.spreadsheet(@test_spreadsheet_id, name: context.test)
-        on_exit fn ->
-            cleanup_table(pid)
-            :ok = Supervisor.terminate_child(GSS.Spreadsheet.Supervisor, pid)
-        end
-        {:ok, spreadsheet: pid}
-    end
+  setup context do
+    {:ok, pid} = GSS.Spreadsheet.Supervisor.spreadsheet(@test_spreadsheet_id, name: context.test)
 
-    @spec cleanup_table(pid) :: :ok
-    defp cleanup_table(pid) do
-        GSS.Spreadsheet.clear_row(pid, 1)
-        GSS.Spreadsheet.clear_row(pid, 2)
-        GSS.Spreadsheet.clear_row(pid, 3)
-        GSS.Spreadsheet.clear_row(pid, 4)
-    end
+    on_exit(fn ->
+      cleanup_table(pid)
+      :ok = Supervisor.terminate_child(GSS.Spreadsheet.Supervisor, pid)
+    end)
 
+    {:ok, spreadsheet: pid}
+  end
 
-    test "initialize new spreadsheet process", %{spreadsheet: pid} do
-        assert GSS.Registry.spreadsheet_pid(@test_spreadsheet_id) == pid
-        assert GSS.Spreadsheet.id(pid) == @test_spreadsheet_id
-    end
+  @spec cleanup_table(pid) :: :ok
+  defp cleanup_table(pid) do
+    GSS.Spreadsheet.clear_row(pid, 1)
+    GSS.Spreadsheet.clear_row(pid, 2)
+    GSS.Spreadsheet.clear_row(pid, 3)
+    GSS.Spreadsheet.clear_row(pid, 4)
+  end
 
-    test "read total number of filled rows", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.rows(pid)
-        assert result == 0
-    end
+  test "initialize new spreadsheet process", %{spreadsheet: pid} do
+    assert GSS.Registry.spreadsheet_pid(@test_spreadsheet_id) == pid
+    assert GSS.Spreadsheet.id(pid) == @test_spreadsheet_id
+  end
 
-    test "read 5 columns from the 1 row in a spreadsheet", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
-        assert result == ["", "", "", "", ""]
-    end
+  test "read total number of filled rows", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.rows(pid)
+    assert result == 0
+  end
 
-    test "write new row lines in the end of document", %{spreadsheet: pid} do
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
-        assert result == @test_row1
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
-        assert result == @test_row2
-    end
+  test "read 5 columns from the 1 row in a spreadsheet", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
+    assert result == ["", "", "", "", ""]
+  end
 
-    test "write some lines and append row between them", %{spreadsheet: pid} do
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
-        :ok = GSS.Spreadsheet.append_row(pid, 1, @test_row3)
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 3, column_to: 3)
-        assert result == @test_row3
-        {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
-        assert result == @test_row2
-    end
+  test "write new row lines in the end of document", %{spreadsheet: pid} do
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 1, column_to: 5)
+    assert result == @test_row1
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
+    assert result == @test_row2
+  end
 
-    test "read batched for 2 rows", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, batch_range: true)
-        assert result == [nil, nil]
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, pad_empty: true)
-        assert result == [["", "", "", "", ""], ["", "", "", "", ""]]
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row1)
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 3, column_to: 5, pad_empty: true)
-        assert result == [["", "", "", "", ""], @test_row1, ["", "", "", "", ""]]
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, ["A1:E1", "A2:E2", "A3:E3"])
-        assert result == [nil, @test_row1, nil]
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, [1, 2, 3], column_to: 5)
-        assert result == [nil, @test_row1, nil]
-    end
+  test "write some lines and append row between them", %{spreadsheet: pid} do
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row2)
+    :ok = GSS.Spreadsheet.append_row(pid, 1, @test_row3)
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 3, column_to: 3)
+    assert result == @test_row3
+    {:ok, result} = GSS.Spreadsheet.read_row(pid, 2, column_to: 6)
+    assert result == @test_row2
+  end
 
-    test "read batched for 3 rows more then 1000 from start", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1000, 1002, column_to: 5)
-        assert result == [nil, nil, nil]
-        :ok = GSS.Spreadsheet.write_row(pid, 1000, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 1001, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 1002, @test_row1)
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1000, 1002, column_to: 5, pad_empty: true)
-        assert result == [@test_row1, @test_row1, @test_row1]
-        GSS.Spreadsheet.clear_row(pid, 1000)
-        GSS.Spreadsheet.clear_row(pid, 1001)
-        GSS.Spreadsheet.clear_row(pid, 1002)
-    end
+  test "read batched for 2 rows", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, batch_range: true)
+    assert result == [nil, nil]
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5, pad_empty: true)
+    assert result == [["", "", "", "", ""], ["", "", "", "", ""]]
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row1)
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 3, column_to: 5, pad_empty: true)
+    assert result == [["", "", "", "", ""], @test_row1, ["", "", "", "", ""]]
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, ["A1:E1", "A2:E2", "A3:E3"])
+    assert result == [nil, @test_row1, nil]
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, [1, 2, 3], column_to: 5)
+    assert result == [nil, @test_row1, nil]
+  end
 
-    test "read batched for 250 rows", %{spreadsheet: pid} do
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 250, column_to: 26, batch_range: true)
-        assert length(result) == 249
-    end
+  test "read batched for 3 rows more then 1000 from start", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1000, 1002, column_to: 5)
+    assert result == [nil, nil, nil]
+    :ok = GSS.Spreadsheet.write_row(pid, 1000, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 1001, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 1002, @test_row1)
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1000, 1002, column_to: 5, pad_empty: true)
+    assert result == [@test_row1, @test_row1, @test_row1]
+    GSS.Spreadsheet.clear_row(pid, 1000)
+    GSS.Spreadsheet.clear_row(pid, 1001)
+    GSS.Spreadsheet.clear_row(pid, 1002)
+  end
 
-    test "clear batched for 2 rows", %{spreadsheet: pid} do
-        :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
-        :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row1)
-        :ok = GSS.Spreadsheet.clear_rows(pid, 1, 2, column_to: 5)
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5)
-        assert result == [nil, nil]
-    end
+  test "read batched for 250 rows", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 250, column_to: 26, batch_range: true)
+    assert length(result) == 249
+  end
 
-    test "write batched for 2 rows", %{spreadsheet: pid} do
-        {:ok, _} = GSS.Spreadsheet.write_rows(pid, ["A2:E2", "A3:F3"], [@test_row1, @test_row2])
-        {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
-        assert result == [@test_row1 ++ [""], @test_row2]
-    end
+  test "clear batched for 2 rows", %{spreadsheet: pid} do
+    :ok = GSS.Spreadsheet.write_row(pid, 1, @test_row1)
+    :ok = GSS.Spreadsheet.write_row(pid, 2, @test_row1)
+    :ok = GSS.Spreadsheet.clear_rows(pid, 1, 2, column_to: 5)
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 2, column_to: 5)
+    assert result == [nil, nil]
+  end
+
+  test "write batched for 2 rows", %{spreadsheet: pid} do
+    {:ok, _} = GSS.Spreadsheet.write_rows(pid, ["A2:E2", "A3:F3"], [@test_row1, @test_row2])
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 2, 3, column_to: 6)
+    assert result == [@test_row1 ++ [""], @test_row2]
+  end
 end

--- a/test/stub_modules/consumer.ex
+++ b/test/stub_modules/consumer.ex
@@ -1,18 +1,18 @@
 defmodule GSS.StubModules.Consumer do
-    def start_link(producer) do
-        GenStage.start_link(__MODULE__, {producer, self()})
-    end
+  def start_link(producer) do
+    GenStage.start_link(__MODULE__, {producer, self()})
+  end
 
-    def init({producer, owner}) do
-        {:consumer, owner, subscribe_to: [producer]}
-    end
+  def init({producer, owner}) do
+    {:consumer, owner, subscribe_to: [producer]}
+  end
 
-    def handle_subscribe(:producer, _, _, state) do
-        {:automatic, state}
-    end
+  def handle_subscribe(:producer, _, _, state) do
+    {:automatic, state}
+  end
 
-    def handle_events(events, _from, owner) do
-        send(owner, {:received, events})
-        {:noreply, [], owner}
-    end
+  def handle_events(events, _from, owner) do
+    send(owner, {:received, events})
+    {:noreply, [], owner}
+  end
 end

--- a/test/stub_modules/producer.ex
+++ b/test/stub_modules/producer.ex
@@ -1,22 +1,22 @@
 defmodule GSS.StubModules.Producer do
-    use GenStage
+  use GenStage
 
-    def start_link(events) do
-       GenStage.start_link(__MODULE__, {events, self()})
-    end
+  def start_link(events) do
+    GenStage.start_link(__MODULE__, {events, self()})
+  end
 
-    def init({events, owner}) do
-        {:producer, {events, owner}}
-    end
+  def init({events, owner}) do
+    {:producer, {events, owner}}
+  end
 
-    def handle_demand(demand, {events, owner}) do
-        {result, tail} = Enum.split(events, demand)
+  def handle_demand(demand, {events, owner}) do
+    {result, tail} = Enum.split(events, demand)
 
-        send(owner, {:handled_demand, result, demand})
-        {:noreply, result, {tail, owner}}
-    end
+    send(owner, {:handled_demand, result, demand})
+    {:noreply, result, {tail, owner}}
+  end
 
-    def handle_call({:add, new_events}, _from, {events, owner}) do
-        {:reply, :ok, [], {events ++ new_events, owner}}
-    end
+  def handle_call({:add, new_events}, _from, {events, owner}) do
+    {:reply, :ok, [], {events ++ new_events, owner}}
+  end
 end


### PR DESCRIPTION
This is a purely cosmetic change to bring the library in line with
standard Elixir. We've had the official formatter since Elixir 1.6 so
this should improve readability and standardise the code a bit.

@Voronchuk - just a head's up I've not run the tests on this as I was struggling a bit with the setup (probably just ineptitude on my part!). However it should be purely cosmetic; I just added `.formatter.exs` and ran `mix format`. Just raising the testing point as you may want to run these if you want to merge this.