### PR TITLE
adding timeout support for "rows" functions

### DIFF
--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -73,9 +73,9 @@ defmodule GSS.Spreadsheet do
   @doc """
   Get total amount of rows in a spreadsheet.
   """
-  @spec rows(pid) :: {:ok, integer()} | {:error, Exception.t()}
-  def rows(pid) do
-    GenServer.call(pid, :rows)
+  @spec rows(pid, Keyword.t()) :: {:ok, integer()} | {:error, Exception.t()}
+  def rows(pid, options \\ []) do
+    gen_server_call(pid, :rows, options)
   end
 
   @doc """


### PR DESCRIPTION
many functions in GSS.Spreadsheet has support for setting timeout. found that rows lacked that support and I needed it. hoping this will be useful other future library users