### PR TITLE
Let read one row with `read_rows`

### DIFF
--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -148,7 +148,7 @@ defmodule GSS.Spreadsheet do
           {:ok, [spreadsheet_data]} | {:error, atom}
   def read_rows(pid, row_index_start, row_index_end, options)
       when is_integer(row_index_start) and is_integer(row_index_end) and
-             row_index_start < row_index_end do
+             row_index_start <= row_index_end do
     gen_server_call(pid, {:read_rows, row_index_start, row_index_end, options}, options)
   end
 

--- a/test/elixir_google_spreadsheets/spreadsheet_test.exs
+++ b/test/elixir_google_spreadsheets/spreadsheet_test.exs
@@ -94,6 +94,11 @@ defmodule GSS.SpreadsheetTest do
     assert result == [nil, @test_row1, nil]
   end
 
+  test "read batched for only 1 row is possible", %{spreadsheet: pid} do
+    {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1, 1, column_to: 5)
+    assert result == [nil]
+  end
+
   test "read batched for 3 rows more then 1000 from start", %{spreadsheet: pid} do
     {:ok, result} = GSS.Spreadsheet.read_rows(pid, 1000, 1002, column_to: 5)
     assert result == [nil, nil, nil]


### PR DESCRIPTION
Sometimes we compute ranges (for eg. see below, chunking to read a great number of rows), and one range ends up containing only one row. In this case it is handy not to have to conditionally use `read_row` but just read this range of one row with `read_rows`.

Example of chunking where we can end up we only a range of one row:

```elixir
{:ok, rows_number} = GSS.Spreadsheet.rows(sheetPid)

1..rows_number
|> Enum.chunk_every(250)
|> Enum.reduce([], fn indexes_chunk, rows ->
  start_range = List.first(indexes_chunk)
  end_range = List.last(indexes_chunk)
  Logger.info("Reading #{start_range}:#{end_range} rows from Sheet")

  {:ok, chunk_rows} =
    GSS.Spreadsheet.read_rows(
      sheetPid,
      start_range,
      end_range,
      timeout: 20000
    )

  rows ++ chunk_rows
end)
```

I've tested this PR in a project, seems to be working as intended.