### PR TITLE
feature/add batch update

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ Sample operations:
 
 * `GSS.Spreadsheet.id(pid)`
 * `GSS.Spreadsheet.properties(pid)`
+* `GSS.Spreadsheet.get_sheet_id(pid)`
+* `GSS.Spreadsheet.add_sheet_id_to_state(pid)`
 * `GSS.Spreadsheet.sheets(pid)`
 * `GSS.Spreadsheet.rows(pid)`
+* `GSS.Spreadsheet.update_sheet_size(pid, 10, 5)`
 * `GSS.Spreadsheet.read_row(pid, 1, column_to: 5)`
 * `GSS.Spreadsheet.read_rows(pid, 1, 10, column_to: 5, pad_empty: true)`
 * `GSS.Spreadsheet.read_rows(pid, [1, 3, 5], column_to: 5, pad_empty: true)`
@@ -84,6 +87,17 @@ Sample operations:
 * `GSS.Spreadsheet.clear_row(pid, 1)`
 * `GSS.Spreadsheet.clear_rows(pid, 1, 10)`
 * `GSS.Spreadsheet.clear_rows(pid, ["A1:E1", "A2:E2"])`
+* `GSS.Spreadsheet.set_basic_filter(pid, %{row_from: 0, row_to: 5, col_from: 1, col_to: 10}, %{col_idx: 2, condition_type: "TEXT_CONTAINS", user_entered_value: "test"})`
+* `GSS.Spreadsheet.set_basic_filter(pid, %{row_from: nil, row_to: nil, col_from: nil, col_to: nil}, %{})`
+* `GSS.Spreadsheet.clear_basic_filter(pid)`
+* `GSS.Spreadsheet.freeze_header(pid, %{dim: :row, n_freeze: 1})`
+* `GSS.Spreadsheet.freeze_header(pid, %{dim: :col, n_freeze: 2})`
+* `GSS.Spreadsheet.update_col_width(pid, %{col_idx: 1, col_width: 200})`
+* `GSS.Spreadsheet.add_number_format(pid, %{row_from: 0, row_to: nil, col_from: 3, col_to: 4}, %{type: "NUMBER", pattern: "#0.0%"})`
+* `GSS.Spreadsheet.update_col_wrap(pid, %{row_from: 0, row_to: nil, col_from: 5, col_to: 7}, %{wrap_strategy: "clip"})`
+* `GSS.Spreadsheet.set_font(pid, %{row_from: nil, row_to: nil, col_from: nil, col_to: nil}, %{font_family: "Source Code Pro"})`
+* `GSS.Spreadsheet.add_conditional_format(pid, %{row_from: nil, row_to: nil, col_from: nil, col_to: nil}, %{formula: "=$E1=\"TEST\"", color_map: %{red: 1, green: 0.8, blue: 0.8}})`
+* `GSS.Spreadsheet.update_border(pid, %{row_from: 0, row_to: 10, col_from: 2, col_to: 5}, %{top: %{red: 1, style: "dashed"}, bottom: %{green: 1, blue: 0.7}, left: %{blue: 0.8, alpha: 0.75}})`
 
 Last function param of `GSS.Spreadsheet` function calls support the same `Keyword` options (in snake_case instead of camelCase), as defined in [Google API Docs](https://developers.google.com/sheets/reference/rest/v4/spreadsheets.values).
 

--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -131,8 +131,7 @@ defmodule GSS.Spreadsheet do
   Append row in a spreadsheet after an index.
   """
   @spec append_row(pid, integer(), spreadsheet_data, Keyword.t()) :: :ok
-  def append_row(pid, row_index, [cell | _] = column_list, options \\ [])
-      when is_binary(cell) or is_nil(cell) do
+  def append_row(pid, row_index, [cell | _] = column_list, options \\ []) when is_binary(cell) or is_nil(cell) do
     gen_server_call(pid, {:append_rows, row_index, [column_list], options}, options)
   end
 
@@ -262,7 +261,7 @@ defmodule GSS.Spreadsheet do
   @doc """
   Clear Basic Filter.
   """
-  @spec clear_basic_filter(pid) :: {:ok, map()} | {:error, Exception.t()}
+  @spec clear_basic_filter(pid, Keyword.t()) :: {:ok, map()} | {:error, Exception.t()}
   def clear_basic_filter(pid, opts \\ [])
 
   def clear_basic_filter(pid, options) do
@@ -450,20 +449,17 @@ defmodule GSS.Spreadsheet do
         _from,
         %{spreadsheet_id: spreadsheet_id, sheet_id: sheet_id} = state
       ) do
-    request_body = %{
-      requests: [
-        %{
-          updateSheetProperties: %{
-            fields: "gridProperties",
-            properties: %{
-              sheetId: sheet_id,
-              gridProperties: %{rowCount: row_count, columnCount: col_count}
-            }
-          }
+    request = %{
+      updateSheetProperties: %{
+        fields: "gridProperties",
+        properties: %{
+          sheetId: sheet_id,
+          gridProperties: %{rowCount: row_count, columnCount: col_count}
         }
-      ]
+      }
     }
 
+    request_body = %{requests: [request]}
     batch_update_query(spreadsheet_id, request_body, options, state)
   end
 

--- a/lib/elixir_google_spreadsheets/spreadsheet.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet.ex
@@ -73,10 +73,10 @@ defmodule GSS.Spreadsheet do
   Get spreadsheet sheets from properties.
   """
   @spec sheets(pid, Keyword.t()) :: [map()] | map()
-  def sheets(pid, opts \\ []) do
-    with {:ok, %{"sheets" => sheets}} <- GenServer.call(pid, :properties),
+  def sheets(pid, options \\ []) do
+    with {:ok, %{"sheets" => sheets}} <- gen_server_call(pid, :properties, options),
          {:is_raw_response?, false, _} <-
-           {:is_raw_response?, Keyword.get(opts, :raw, false), sheets} do
+           {:is_raw_response?, Keyword.get(options, :raw, false), sheets} do
       Enum.reduce(sheets, %{}, fn %{"properties" => %{"title" => title} = properties}, acc ->
         Map.put(acc, title, properties)
       end)

--- a/lib/elixir_google_spreadsheets/spreadsheet/supervisor.ex
+++ b/lib/elixir_google_spreadsheets/spreadsheet/supervisor.ex
@@ -33,7 +33,14 @@ defmodule GSS.Spreadsheet.Supervisor do
         }
 
         {:ok, pid} = DynamicSupervisor.start_child(__MODULE__, spec)
-        :ok = GSS.Registry.new_spreadsheet(spreadsheet_id, pid, opts)
+
+        {:ok, nil} = GSS.Spreadsheet.add_sheet_id_to_state(pid)
+
+        {:ok, sheet_id} = GSS.Spreadsheet.get_sheet_id(pid)
+
+        new_opts = Keyword.put(opts, :sheet_id, sheet_id)
+        :ok = GSS.Registry.new_spreadsheet(spreadsheet_id, pid, new_opts)
+
         {:ok, pid}
     end
   end


### PR DESCRIPTION
This PR adds some of the functionality from [spreadsheets.batchUpdate](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/batchUpdate), which is different from spreadsheets.values.batchUpdate (i.e. writing values in a batch).

These functions in `GSS.Spreadsheet` include setting a basic filter, freezing header rows, and adding number formats. 
Each batchUpdate function has a client-side function that accepts up to 4 arguments: `pid`, `range`, `params`, `options`.

Any of these functions that require a range will use [GridRange](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#GridRange). use the helper function `grid_range/2` to format.

These functions assume you submit a `list_name` (i.e. specify a sheet to operate on). In order to only make one call to `:properties` and retrieve the necessary sheet_id for these operations, `sheet_id` has been added to the spreadsheet state in `GSS.Spreadsheet.Supervisor`.`

Tests and/or doctests have not been added but can be.